### PR TITLE
Added notcontains handlebars helper

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -10,10 +10,24 @@ Handlebars.registerHelper('json', function (object) {
   return new Handlebars.SafeString(JSON.stringify(object, null, 2))
 })
 
-Handlebars.registerHelper('notmerge', function(object) {
-  if (object.subject.indexOf('Merge branch ') < 0) {
-    return object;
-  }
+Handlebars.registerHelper('notcontains', function(collection, item, options) {
+  // string check
+	if(typeof collection === 'string'){
+		if( collection.search(item) < 0){
+			return options.fn(this);
+		} else {
+			return options.inverse(this);
+		}
+	}
+  
+	// "collection" check (objects & arrays)
+	for (var prop in collection) {
+		if (collection.hasOwnProperty(prop)){
+			if(collection[prop] !== item) return options.fn(this);
+		}
+	}
+
+	return options.inverse(this);
 });
 
 async function getTemplate (template) {

--- a/src/template.js
+++ b/src/template.js
@@ -10,6 +10,12 @@ Handlebars.registerHelper('json', function (object) {
   return new Handlebars.SafeString(JSON.stringify(object, null, 2))
 })
 
+Handlebars.registerHelper('notmerge', function(object) {
+  if (object.subject.indexOf('Merge branch ') < 0) {
+    return object;
+  }
+});
+
 async function getTemplate (template) {
   if (await pathExists(template)) {
     return readFile(template, 'utf-8')


### PR DESCRIPTION
This adds the not contains helper for the handlebars template.  As a result, I can now do the following:

```
{{#each releases}}

  # [{{title}}[({{href}}) - {{niceDate}}

  {{#each commits}}
    {{#notcontains subject 'Merge branch '}}  
      - [{{subject}}]({{href}})
    {{/notcontains}}
  {{/each}}
{{/each}}

```