### PR TITLE
Feat: match template helper

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -44,7 +44,7 @@ Handlebars.registerHelper('commit-list', function (context, options) {
 })
 
 Handlebars.registerHelper('matches', function (val, pattern, options) {
-  const r = new RegExp(pattern)
+  const r = new RegExp(pattern, options.hash.flags || '')
   return r.test(val) ? options.fn(this) : options.inverse(this)
 })
 

--- a/src/template.js
+++ b/src/template.js
@@ -43,6 +43,11 @@ Handlebars.registerHelper('commit-list', function (context, options) {
   return `${options.hash.heading}\n${list}`
 })
 
+Handlebars.registerHelper('matches', function (val, pattern, options) {
+  const r = new RegExp(pattern)
+  return r.test(val) ? options.fn(this) : options.inverse(this)
+})
+
 async function getTemplate (template) {
   if (await pathExists(template)) {
     return readFile(template, 'utf-8')

--- a/test/template.js
+++ b/test/template.js
@@ -114,3 +114,70 @@ describe('commit-list helper', () => {
     expect(compile({ commits })).to.equal(expected)
   })
 })
+
+describe('matches helper', () => {
+  const compileCommits = (matches) => Handlebars.compile(
+    '{{#each releases}}\n' +
+      '{{#each commits}}\n' +
+        matches +
+      '{{/each}}\n' +
+    '{{/each}}'
+  )
+
+  it('matches on field value', () => {
+    const matches =
+      '{{#matches href "12c0624"}}\n' +
+        '- {{message}}\n' +
+      '{{/matches}}\n'
+    const expected =
+      '- Commit that fixes nothing\n'
+    expect(compileCommits(matches)({ releases })).to.equal(expected)
+  })
+
+  it('matches with case insensitive flag', () => {
+    const matches =
+      '{{#matches author "pete" flags="i"}}\n' +
+        '- {{shorthash}}\n' +
+      '{{/matches}}\n'
+    const expected =
+      '- b0b3040\n' +
+      '- 12c0624\n' +
+      '- e9a43b2\n' +
+      '- 158fdde\n'
+    expect(compileCommits(matches)({ releases })).to.equal(expected)
+  })
+
+  it('provides non-matching conditional', () => {
+    const matches =
+      '{{#matches shorthash "e9a43b2"}}\n' +
+        '- HIT {{date}}\n' +
+      '{{else}}\n' +
+        '- MISS {{date}}\n' +
+      '{{/matches}}\n'
+    const expected =
+      '- MISS 2015-12-29T21:57:19.000Z\n' +
+      '- MISS 2015-12-29T21:18:19.000Z\n' +
+      '- HIT 2015-12-29T21:19:19.000Z\n' +
+      '- MISS 2015-12-14T17:06:12.000Z\n'
+    expect(compileCommits(matches)({ releases })).to.equal(expected)
+  })
+
+  it('matches on multiline content', () => {
+    const multiReleases = [{ commits: [
+      {
+        shorthash: 'c0f25d7',
+        message: 'Hello\n\nWorld\n\nBREAKING CHANGE: mock break\n\nsome more text'
+      }, {
+        shorthash: '12cd728',
+        message: 'Nope'
+      }
+    ]}]
+    const matches =
+      '{{#matches message "BREAKING CHANGE"}}\n' +
+        '- {{shorthash}}\n' +
+      '{{/matches}}\n'
+    const expected =
+      '- c0f25d7\n'
+    expect(compileCommits(matches)({ releases: multiReleases })).to.equal(expected)
+  })
+})


### PR DESCRIPTION
Adds a `matches` helper to the handlebars runtime, which allows for matching a value from the commit objects based on some pattern. It uses `RegExp` behind the scenes.

> `{{#matches message "BREAKING"}}**BREAKING**{{/matches}}`

You can also optionally pass flags into `RegExp` constructor.

> `{{#matches message "breaking" flags="i"}}**BREAKING**{{/matches}}`

It also supports inverse matching, in case that's useful.

> `{{#matches message "breaking" flags="i"}}**BREAKING**{{else}}*non-breaking*{{/matches}}`

This allows users to get some base functionality to meet #39 as part of the template.

Happy to add tests, just let me know what you'd like to see.