### PR TITLE
Fix releases sorting when unreleased enabled

### DIFF
--- a/src/releases.js
+++ b/src/releases.js
@@ -39,7 +39,7 @@ export function parseReleases (commits, remote, latestVersion, options) {
 }
 
 export function sortReleases (a, b) {
-  return a.tag && b.tag ? semver.rcompare(a.tag, b.tag) : 0
+  return a.tag && b.tag ? semver.rcompare(a.tag, b.tag) : -1
 }
 
 function newRelease (tag = null, date = new Date().toISOString()) {

--- a/src/releases.js
+++ b/src/releases.js
@@ -39,15 +39,10 @@ export function parseReleases (commits, remote, latestVersion, options) {
 }
 
 export function sortReleases (a, b) {
-  if (a.tag && b.tag) {
-    return semver.rcompare(a.tag, b.tag)
-  } else if (!b.tag) {
-    return -1
-  } else if (!a.tag) {
-    return 1
-  } else {
-    return 0
-  }
+  if (a.tag && b.tag) return semver.rcompare(a.tag, b.tag)
+  if (a.tag) return -1
+  if (b.tag) return 1
+  return 0
 }
 
 function newRelease (tag = null, date = new Date().toISOString()) {

--- a/src/releases.js
+++ b/src/releases.js
@@ -39,7 +39,15 @@ export function parseReleases (commits, remote, latestVersion, options) {
 }
 
 export function sortReleases (a, b) {
-  return a.tag && b.tag ? semver.rcompare(a.tag, b.tag) : -1
+  if (a.tag && b.tag) {
+    return semver.rcompare(a.tag, b.tag)
+  } else if (!b.tag) {
+    return -1
+  } else if (!a.tag) {
+    return 1
+  } else {
+    return 0
+  }
 }
 
 function newRelease (tag = null, date = new Date().toISOString()) {

--- a/test/releases.js
+++ b/test/releases.js
@@ -26,6 +26,11 @@ describe('parseReleases', () => {
     expect(releases[0].href).to.equal('https://bitbucket.org/user/repo/compare/v1.0.0%0Dv0.1.0')
   })
 
+  it('sorts releases in the correct order', () => {
+    const tags = parseReleases(commits, remotes.bitbucket, null, options).map(item => { return item.tag })
+    expect(tags).to.deep.equal(['v1.0.0', 'v0.1.0', 'v0.0.2', 'v0.0.1'])
+  })
+
   it('includes tag prefix in compare urls', () => {
     const releases = parseReleases(commits, remotes.bitbucket, null, { ...options, tagPrefix: 'prefix-' })
     expect(releases[0].href).to.equal('https://bitbucket.org/user/repo/compare/prefix-v1.0.0%0Dprefix-v0.1.0')

--- a/test/releases.js
+++ b/test/releases.js
@@ -27,7 +27,7 @@ describe('parseReleases', () => {
   })
 
   it('sorts releases in the correct order', () => {
-    const tags = parseReleases(commits, remotes.bitbucket, null, options).map(item => { return item.tag })
+    const tags = parseReleases(commits, remotes.bitbucket, null, options).map(item => { return item.tag })
     expect(tags).to.deep.equal(['v1.0.0', 'v0.1.0', 'v0.0.2', 'v0.0.1'])
   })
 


### PR DESCRIPTION
Starting `v1.6.0`, the generated changelogs had weird differences :

`v1.5.0`
![capture d ecran 2018-05-29 a 15 48 47](https://user-images.githubusercontent.com/1873323/40669077-5e7b532e-6366-11e8-8f88-cdb53ba4dd4d.png)

`v1.6.0`
![capture d ecran 2018-05-29 a 15 49 52](https://user-images.githubusercontent.com/1873323/40669088-66a73144-6366-11e8-8b27-e947d1043d19.png)

As stated in the [ECMAScript 5.1 definition of Array.sort](https://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.11), the comparison function should return 0 only when a = b, __which is not really the case between `null` (unreleased) and `v2.1.1`__

Please let me know if anything is wrong with this PR 😄 