### PR TITLE
Add support for `.auto-changelog` default config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ You can also set any option in `package.json` under the `auto-changelog` key, us
 }
 ```
 
+If you'd like to use a global installation of `auto-changelog` in a non-NodeJS project that wouldn't otherwise have a `package.json` file, you can include a `.auto-changelog` file in your project root with your defaults in order to avoid needing to specify command-line options for every run:
+
+```js
+{
+  "output": "HISTORY.md",
+  "template": "keepachangelog",
+  "unreleased": true,
+  "commitLimit": false
+}
+```
+
+**Note:** You cannot use the `.auto-changelog` convention if you have already defined defaults in `package.json`.
+
 ### Requirements
 
 `auto-changelog` is designed to be as flexible as possible, providing a clear changelog for any project. There are only two absolute requirements:

--- a/test/run.js
+++ b/test/run.js
@@ -14,13 +14,13 @@ import run, {
 const getOptions = __get__('getOptions')
 
 describe('getOptions', () => {
-  it('parses commit limit correctly', () => {
-    const options = getOptions(['', '', '--commit-limit', '10'])
+  it('parses commit limit correctly', async () => {
+    const options = await getOptions(['', '', '--commit-limit', '10'])
     expect(options.commitLimit).to.equal(10)
   })
 
-  it('parses false commit limit correctly', () => {
-    const options = getOptions(['', '', '--commit-limit', 'false'])
+  it('parses false commit limit correctly', async () => {
+    const options = await getOptions(['', '', '--commit-limit', 'false'])
     expect(options.commitLimit).to.equal(false)
   })
 })

--- a/test/run.js
+++ b/test/run.js
@@ -131,6 +131,50 @@ describe('run', () => {
     return run(['', '', '--output', 'should-be-this.md'])
   })
 
+  it('uses options from .auto-changelog', async () => {
+    const expected = await readFile(join(__dirname, 'data', 'template-keepachangelog.md'))
+    mock('fileExists', (fileName) => {
+      return fileName == '.auto-changelog'
+    })
+    mock('readJson', (fileName) => {
+      return fileName == '.auto-changelog' ? {template: 'keepachangelog'} : null
+    })
+    mock('writeFile', (output, log) => {
+      expect(output).to.equal('CHANGELOG.md')
+      expect(log).to.equal(expected)
+    })
+
+    return run(['', ''])
+  })
+
+  it('command line options override options from .auto-changelog', async () => {
+    mock('fileExists', (fileName) => {
+      return fileName == '.auto-changelog'
+    })
+    mock('readJson', (fileName) => {
+      return fileName == '.auto-changelog' ? {output: 'should-not-be-this.md'} : null
+    })
+    mock('writeFile', (output, log) => {
+      expect(output).to.equal('should-be-this.md')
+    })
+
+    return run(['', '', '--output', 'should-be-this.md'])
+  })
+
+  it('.auto-changelog is ignored if package.json options are set', async () => {
+    mock('fileExists', () => true)
+    mock('readJson', () => ({
+      'auto-changelog': {
+        output: 'should-be-this.md'
+      }
+    }))
+    mock('writeFile', (output, log) => {
+      expect(output).to.equal('should-be-this.md')
+    })
+
+    return run(['', ''])
+  })
+
   it('supports unreleased option', () => {
     mock('writeFile', (output, log) => {
       expect(log).to.include('Unreleased')

--- a/test/run.js
+++ b/test/run.js
@@ -134,10 +134,10 @@ describe('run', () => {
   it('uses options from .auto-changelog', async () => {
     const expected = await readFile(join(__dirname, 'data', 'template-keepachangelog.md'))
     mock('fileExists', (fileName) => {
-      return fileName == '.auto-changelog'
+      return fileName === '.auto-changelog'
     })
     mock('readJson', (fileName) => {
-      return fileName == '.auto-changelog' ? {template: 'keepachangelog'} : null
+      return fileName === '.auto-changelog' ? {template: 'keepachangelog'} : null
     })
     mock('writeFile', (output, log) => {
       expect(output).to.equal('CHANGELOG.md')
@@ -149,10 +149,10 @@ describe('run', () => {
 
   it('command line options override options from .auto-changelog', async () => {
     mock('fileExists', (fileName) => {
-      return fileName == '.auto-changelog'
+      return fileName === '.auto-changelog'
     })
     mock('readJson', (fileName) => {
-      return fileName == '.auto-changelog' ? {output: 'should-not-be-this.md'} : null
+      return fileName === '.auto-changelog' ? {output: 'should-not-be-this.md'} : null
     })
     mock('writeFile', (output, log) => {
       expect(output).to.equal('should-be-this.md')


### PR DESCRIPTION
I have a few projects where I'd like to use this tool to maintain the CHANGELOG, but they don't use NodeJS at all. Rather than create a `package.json` file in those repositories, which could cause confusion to someone new to the projects, I thought it'd be very helpful to use a platform-agnostic configuration file with the defaults I'd like to use.

This way, I can install `auto-changelog` using the `-g` option with NPM and use it without having to remember which defaults I want to use.

PR includes tests, and I don't believe this breaks BC in any way (`.auto-changelog` is optional, `package.json` still works, and a warning will be displayed if someone tries to use both `.auto-changelog` and `package.json` settings at the same time).

I realize this hasn't been raised in the issue tracker, so hopefully that won't be a problem with getting this merged. Happy to make tweaks, if needed.