### PR TITLE
Option to disable semver format validation

### DIFF
--- a/src/commits.js
+++ b/src/commits.js
@@ -80,7 +80,7 @@ function getTag (refs, options) {
     const prefix = `tag: ${options.tagPrefix}`
     if (ref.indexOf(prefix) === 0) {
       const version = ref.replace(prefix, '')
-      if (semver.valid(version)) {
+      if (options.disableSemver || semver.valid(version)) {
         return version
       }
     }

--- a/src/commits.js
+++ b/src/commits.js
@@ -18,6 +18,10 @@ const MERGE_PATTERNS = [
   /Merge branch .+ into .+\n\n(.+)[\S\s]+See merge request [^!]*!(\d+)/ // GitLab merge
 ]
 
+export const ParseStats = {
+  ignoredTags: 0
+}
+
 export async function fetchCommits (remote, options, branch = null) {
   const command = branch ? `git log ${branch}` : 'git log'
   const format = await getLogFormat()
@@ -80,8 +84,14 @@ function getTag (refs, options) {
     const prefix = `tag: ${options.tagPrefix}`
     if (ref.indexOf(prefix) === 0) {
       const version = ref.replace(prefix, '')
-      if (options.disableSemver || semver.valid(version)) {
+      if (options.disableSemver) {
         return version
+      } else {
+        if (semver.valid(version)) {
+          return version
+        } else {
+          ParseStats.ignoredTags++
+        }
       }
     }
   }

--- a/src/releases.js
+++ b/src/releases.js
@@ -17,7 +17,7 @@ export function parseReleases (commits, remote, latestVersion, options) {
             remote
           ),
           commits: release.commits.sort(sortCommits),
-          major: commit.tag && release.tag && semver.diff(commit.tag, release.tag) === 'major'
+          major: !options.disableSemver && commit.tag && release.tag && semver.diff(commit.tag, release.tag) === 'major'
         })
       }
       release = newRelease(commit.tag, commit.date)
@@ -37,8 +37,15 @@ export function parseReleases (commits, remote, latestVersion, options) {
   return releases
 }
 
-export function sortReleases (a, b) {
+export function sortReleasesBySemver (a, b) {
   if (a.tag && b.tag) return semver.rcompare(a.tag, b.tag)
+  if (a.tag) return 1
+  if (b.tag) return -1
+  return 0
+}
+
+export function sortReleasesByStr (a, b) {
+  if (a.tag && b.tag) return b.tag.localeCompare(a.tag)
   if (a.tag) return 1
   if (b.tag) return -1
   return 0

--- a/src/run.js
+++ b/src/run.js
@@ -92,8 +92,6 @@ export default async function run (argv) {
   if (ParseStats.ignoredTags) {
     warnings.push(`(${ParseStats.ignoredTags} invalid semver tags)`)
   }
-  console.log(ParseStats)
-
   const latestVersion = getLatestVersion(options, pkg, commits)
   const releases = await getReleases(commits, remote, latestVersion, options)
   const log = await compileTemplate(options.template, { releases })

--- a/src/run.js
+++ b/src/run.js
@@ -4,7 +4,7 @@ import uniqBy from 'lodash.uniqby'
 import { version } from '../package.json'
 import { fetchRemote } from './remote'
 import { fetchCommits } from './commits'
-import { parseReleases, sortReleases } from './releases'
+import { parseReleases, sortReleasesBySemver, sortReleasesByStr } from './releases'
 import { compileTemplate } from './template'
 import { parseLimit, readJson, writeFile, fileExists } from './utils'
 
@@ -13,7 +13,8 @@ const DEFAULT_OPTIONS = {
   template: 'compact',
   remote: 'origin',
   commitLimit: 3,
-  tagPrefix: ''
+  tagPrefix: '',
+  disableSemver: false
 }
 
 const PACKAGE_OPTIONS_KEY = 'auto-changelog'
@@ -28,6 +29,7 @@ function getOptions (argv, pkg) {
     .option('-u, --unreleased', 'include section for unreleased changes')
     .option('-l, --commit-limit [count]', `number of commits to display per release, default: ${DEFAULT_OPTIONS.commitLimit}`, parseLimit)
     .option('-i, --issue-url [url]', `override url for issues, use {id} for issue id`)
+    .option('-d, --disable-semver', `disable semantic versioning (semver), uses raw tags`)
     .option('--issue-pattern [regex]', `override regex pattern for issues in commit messages`)
     .option('--breaking-pattern [regex]', `regex pattern for breaking change commits`)
     .option('--ignore-commit-pattern [regex]', `pattern to ignore when parsing commits`)
@@ -78,7 +80,7 @@ async function getReleases (commits, remote, latestVersion, options) {
       ]
     }
   }
-  return uniqBy(releases, 'tag').sort(sortReleases)
+  return uniqBy(releases, 'tag').sort(options.disableSemver ? sortReleasesByStr : sortReleasesBySemver)
 }
 
 export default async function run (argv) {


### PR DESCRIPTION
In our project we use a different (non semver) tag format, resulting in (almost) all tags being ignored by auto-changelog.

This tags adds a flag `-d` or `--disable-semver` to disable tag parsing by semver. In this mode, all tags are fetched and listed; and sorted just lexicographically (with String's `localeCompare()`). It also adds a warning with the count of ignored tags in the default (semver) mode, so you know why your tags are not being listed in the changelog.

Example output:

```
$ ../auto-changelog/lib/index.js
8187 bytes written to CHANGELOG.md. (45 invalid semver tags)
$ ../auto-changelog/lib/index.js -d
101710 bytes written to CHANGELOG.md
```

And output of `-h` now includes:

```
...
  -d, --disable-semver             disable semantic versioning (semver), uses raw tags
...
```