### PR TITLE
Add --merge-pattern option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
   -i, --issue-url [url]               # override url for issues, use {id} for issue id
       --issue-pattern [regex]         # override regex pattern for issues in commit messages
       --breaking-pattern [regex]      # regex pattern for breaking change commits
-      --merge-pattern [regex]         # override regex pattern for merge commits
+      --merge-pattern [regex]         # add custom regex pattern for merge commits
       --ignore-commit-pattern [regex] # pattern to ignore when parsing commits
       --tag-pattern [regex]           # override regex pattern for release tags
       --tag-prefix [prefix]           # prefix used in version tags, default: v

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
   -i, --issue-url [url]               # override url for issues, use {id} for issue id
       --issue-pattern [regex]         # override regex pattern for issues in commit messages
       --breaking-pattern [regex]      # regex pattern for breaking change commits
+      --merge-pattern [regex]         # override regex pattern for merge commits
       --ignore-commit-pattern [regex] # pattern to ignore when parsing commits
       --tag-pattern [regex]           # override regex pattern for release tags
       --tag-prefix [prefix]           # prefix used in version tags, default: v

--- a/src/commits.js
+++ b/src/commits.js
@@ -141,9 +141,17 @@ function getFixPattern (options) {
   return DEFAULT_FIX_PATTERN
 }
 
+function getMergePatterns (options) {
+  if (options.mergePattern) {
+    return [new RegExp(options.mergePattern, 'g')]
+  }
+  return MERGE_PATTERNS
+}
+
 function getMerge (message, author, remote, options = {}) {
-  for (let pattern of MERGE_PATTERNS) {
-    const match = message.match(pattern)
+  const patterns = getMergePatterns(options)
+  for (let pattern of patterns) {
+    const match = pattern.exec(message)
     if (match) {
       const id = /^\d+$/.test(match[1]) ? match[1] : match[2]
       const message = /^\d+$/.test(match[1]) ? match[2] : match[1]

--- a/src/commits.js
+++ b/src/commits.js
@@ -143,7 +143,7 @@ function getFixPattern (options) {
 
 function getMergePatterns (options) {
   if (options.mergePattern) {
-    return [new RegExp(options.mergePattern, 'g')]
+    return MERGE_PATTERNS.concat(new RegExp(options.mergePattern, 'g'))
   }
   return MERGE_PATTERNS
 }

--- a/src/run.js
+++ b/src/run.js
@@ -34,7 +34,7 @@ function getOptions (argv, pkg, dotOptions) {
     .option('-i, --issue-url [url]', 'override url for issues, use {id} for issue id')
     .option('--issue-pattern [regex]', 'override regex pattern for issues in commit messages')
     .option('--breaking-pattern [regex]', 'regex pattern for breaking change commits')
-    .option('--merge-pattern [regex]', 'override regex pattern for merge commits')
+    .option('--merge-pattern [regex]', 'add custom regex pattern for merge commits')
     .option('--ignore-commit-pattern [regex]', 'pattern to ignore when parsing commits')
     .option('--tag-pattern [regex]', 'override regex pattern for release tags')
     .option('--tag-prefix [prefix]', 'prefix used in version tags')

--- a/src/run.js
+++ b/src/run.js
@@ -34,6 +34,7 @@ function getOptions (argv, pkg, dotOptions) {
     .option('-i, --issue-url [url]', 'override url for issues, use {id} for issue id')
     .option('--issue-pattern [regex]', 'override regex pattern for issues in commit messages')
     .option('--breaking-pattern [regex]', 'regex pattern for breaking change commits')
+    .option('--merge-pattern [regex]', 'override regex pattern for merge commits')
     .option('--ignore-commit-pattern [regex]', 'pattern to ignore when parsing commits')
     .option('--tag-pattern [regex]', 'override regex pattern for release tags')
     .option('--tag-prefix [prefix]', 'prefix used in version tags')

--- a/test/commits.js
+++ b/test/commits.js
@@ -314,6 +314,20 @@ describe('getMerge', () => {
     })
   })
 
+  it('supports mergePattern parameter', () => {
+    const options = {
+      mergePattern: 'PR #(\\d+) from .+\\n\\n.+\\n(.+)'
+    }
+
+    const message = 'PR #37 from repo/branch\n\ncommit sha512\nPull request title'
+    expect(getMerge(message, 'Commit Author', remotes.github, options)).to.deep.equal({
+      id: '37',
+      message: 'Pull request title',
+      href: 'https://github.com/user/repo/pull/37',
+      author: 'Commit Author'
+    })
+  })
+
   it('supports replaceText option', () => {
     const message = 'Merge pull request #3 from repo/branch\n\nPull request title'
     const options = {


### PR DESCRIPTION
This will allow the user to specify a regex which will be used to find merge commits.