### PR TITLE
Add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "auto-changelog",
   "version": "1.11.0",
   "description": "Command line tool for generating a changelog from git tags and commit history",
+  "main": "./lib/index.js",
   "bin": {
     "auto-changelog": "./lib/index.js"
   },


### PR DESCRIPTION
This change would allow to call the tool directly from my node release script like this 
```require ("auto-changelog");```
Not the nicest way but works for me ;-)