### PR TITLE
Add --sort-commits-by-date option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options:
       --tag-pattern [regex]           # override regex pattern for release tags
       --tag-prefix [prefix]           # prefix used in version tags, default: v
       --starting-commit [hash]        # starting commit to use for changelog generation
+      --sort-commits-by-date          # sort commits by date (descending) instead of sorting by relevance
       --include-branch [branch]       # one or more branches to include commits from, comma separated
       --release-summary               # display tagged commit message body as release summary
       --stdout                        # output changelog to stdout

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ npm install -g auto-changelog
 
 ### Usage
 
-Simply run `auto-changelog` in the root folder of a git repository. `git log` is run behind the scenes in order to parse the commit history.
+Simply run `auto-changelog` in the root folder of a git repository.
+
+Behind the scenes, `git log` is run in order to parse the commit history. Commits are ordered by relevance by default (i.e. breaking changes first, followed by commits that made the most changes). To order by date instead, see the `--sort-commits-by-date` option below.
 
 ```bash
 Usage: auto-changelog [options]

--- a/src/releases.js
+++ b/src/releases.js
@@ -6,6 +6,7 @@ const COMMIT_MESSAGE_PATTERN = /\n+([\S\s]+)/
 const NUMERIC_PATTERN = /^\d+(\.\d+)?$/
 
 export function parseReleases (commits, remote, latestVersion, options) {
+  const sortCommits = options.sortCommitsByDate ? sortCommitsByDateDescending : sortCommitsByRelevance
   let release = newRelease(latestVersion)
   const releases = []
   for (let commit of commits) {
@@ -117,10 +118,14 @@ function getSummary (message, releaseSummary) {
   return null
 }
 
-function sortCommits (a, b) {
+function sortCommitsByRelevance (a, b) {
   if (!a.breaking && b.breaking) return 1
   if (a.breaking && !b.breaking) return -1
   return (b.insertions + b.deletions) - (a.insertions + a.deletions)
+}
+
+function sortCommitsByDateDescending (a, b) {
+  return a.date < b.date ? 1 : -1
 }
 
 function sliceCommits (commits, options, release) {

--- a/src/run.js
+++ b/src/run.js
@@ -38,6 +38,7 @@ function getOptions (argv, pkg, dotOptions) {
     .option('--tag-pattern [regex]', 'override regex pattern for release tags')
     .option('--tag-prefix [prefix]', 'prefix used in version tags')
     .option('--starting-commit [hash]', 'starting commit to use for changelog generation')
+    .option('--sort-commits-by-date', 'sort commits by date (descending) instead of sorting by relevance')
     .option('--include-branch [branch]', 'one or more branches to include commits from, comma separated', str => str.split(','))
     .option('--release-summary', 'use tagged commit message body as release summary')
     .option('--stdout', 'output changelog to stdout')


### PR DESCRIPTION
This PR adds an option `--sort-commits-by-date` option, and adds an extra explanation to README.

Fixes #95.