### PR TITLE
Add support for alternate date sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
       --tag-pattern [regex]           # override regex pattern for release tags
       --tag-prefix [prefix]           # prefix used in version tags, default: v
       --starting-commit [hash]        # starting commit to use for changelog generation
-      --sort-commits [property]       # sort commits by property [relevance, date], default: relevance
+      --sort-commits [property]       # sort commits by property [relevance, date, date-desc], default: relevance
       --include-branch [branch]       # one or more branches to include commits from, comma separated
       --release-summary               # display tagged commit message body as release summary
       --handlebars-setup              # handlebars setup file

--- a/src/releases.js
+++ b/src/releases.js
@@ -152,8 +152,8 @@ function commitSorter ({ sortCommits }) {
   return (a, b) => {
     if (!a.breaking && b.breaking) return 1
     if (a.breaking && !b.breaking) return -1
-    if (sortCommits === 'date') return new Date(a.date) - new Date(b.date);
-    if (sortCommits === 'datedesc') return new Date(b.date) - new Date(a.date);
+    if (sortCommits === 'date') return new Date(a.date) - new Date(b.date)
+    if (sortCommits === 'datedesc') return new Date(b.date) - new Date(a.date)
     return (b.insertions + b.deletions) - (a.insertions + a.deletions)
   }
 }

--- a/src/releases.js
+++ b/src/releases.js
@@ -153,7 +153,7 @@ function commitSorter ({ sortCommits }) {
     if (!a.breaking && b.breaking) return 1
     if (a.breaking && !b.breaking) return -1
     if (sortCommits === 'date') return new Date(a.date) - new Date(b.date)
-    if (sortCommits === 'datedesc') return new Date(b.date) - new Date(a.date)
+    if (sortCommits === 'date-desc') return new Date(b.date) - new Date(a.date)
     return (b.insertions + b.deletions) - (a.insertions + a.deletions)
   }
 }

--- a/src/releases.js
+++ b/src/releases.js
@@ -152,7 +152,8 @@ function commitSorter ({ sortCommits }) {
   return (a, b) => {
     if (!a.breaking && b.breaking) return 1
     if (a.breaking && !b.breaking) return -1
-    if (sortCommits === 'date') return new Date(a.date) - new Date(b.date)
+    if (sortCommits === 'date') return new Date(a.date) - new Date(b.date);
+    if (sortCommits === 'datedesc') return new Date(b.date) - new Date(a.date);
     return (b.insertions + b.deletions) - (a.insertions + a.deletions)
   }
 }

--- a/src/run.js
+++ b/src/run.js
@@ -40,7 +40,7 @@ async function getOptions (argv) {
     .option('--tag-pattern [regex]', 'override regex pattern for release tags')
     .option('--tag-prefix [prefix]', 'prefix used in version tags')
     .option('--starting-commit [hash]', 'starting commit to use for changelog generation')
-    .option('--sort-commits [property]', `sort commits by property, default: ${DEFAULT_OPTIONS.sortCommits}`)
+    .option('--sort-commits [property]', `sort commits by property [relevance, date, date-desc], default: ${DEFAULT_OPTIONS.sortCommits}`)
     .option('--include-branch [branch]', 'one or more branches to include commits from, comma separated', str => str.split(','))
     .option('--release-summary', 'use tagged commit message body as release summary')
     .option('--handlebars-setup', 'handlebars setup file')


### PR DESCRIPTION
Currently commits are sorted such that oldest are shown first. Add a new sort option to allow for newer to be shown first.