### PR TITLE
Add mercurial partial compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
       --handlebars-setup [file]       # handlebars setup file
       --append-git-log [string]       # string to append to git log command
       --stdout                        # output changelog to stdout
+      --mercurial-compat              # simplified compatibility mode with mercurial repositories
   -V, --version                       # output the version number
   -h, --help                          # output usage information
 

--- a/src/remote.js
+++ b/src/remote.js
@@ -2,7 +2,7 @@ import parseRepoURL from 'parse-github-url'
 import { cmd } from './utils'
 
 export async function fetchRemote (options) {
-  const remoteURL = await cmd(`git config --get remote.${options.remote}.url`)
+  const remoteURL = options.mercurialCompat ? null : await cmd(`git config --get remote.${options.remote}.url`)
   return getRemote(remoteURL, options)
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -51,6 +51,7 @@ async function getOptions (argv) {
     .option('--handlebars-setup <file>', 'handlebars setup file')
     .option('--append-git-log <string>', 'string to append to git log command')
     .option('--stdout', 'output changelog to stdout')
+    .option('--mercurial-compat', 'Simplified compatibility mode with mercurial repositories')
     .version(version)
     .parse(argv)
 
@@ -105,6 +106,7 @@ export default async function run (argv) {
   log('Fetching remote…')
   const remote = await fetchRemote(options)
   const commitProgress = bytes => log(`Fetching commits… ${formatBytes(bytes)} loaded`)
+  log('Fetching commits…')
   const commits = await fetchCommits(remote, options, null, commitProgress)
   log('Generating changelog…')
   const latestVersion = await getLatestVersion(options, commits)

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,8 @@ export function formatBytes (bytes) {
 
 // Simple util for calling a child process
 export function cmd (string, onProgress) {
-  const [cmd, ...args] = string.trim().split(' ')
+  // Split only on spaces outside of quoted string, i.e. those followed by an even number of quotes
+  const [cmd, ...args] = string.trim().split(/ +(?=(?:(?:[^"]*"){2})*[^"]*$)(?=(?:(?:[^']*'){2})*[^']*$)/g)
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args)
     let data = ''
@@ -38,6 +39,18 @@ export async function getGitVersion () {
   const output = await cmd('git --version')
   const match = output.match(/\d+\.\d+\.\d+/)
   return match ? match[0] : null
+}
+
+export async function getHgVersion () {
+  const output = await cmd('hg --version')
+  let match = output.match(/\d+\.\d+\.\d+/)
+  if (match) {
+    return match[0]
+  } else {
+    // Mercurial releases omit the patch version .0
+    match = output.match(/\d+\.\d+/)
+    return match ? `${match[0]}.0` : null
+  }
 }
 
 export function niceDate (string) {

--- a/test/commits.js
+++ b/test/commits.js
@@ -19,7 +19,8 @@ const getSubject = __get__('getSubject')
 const getLogFormat = __get__('getLogFormat')
 
 const options = {
-  tagPrefix: ''
+  tagPrefix: '',
+  mercurialCompat: false
 }
 
 describe('fetchCommits', () => {
@@ -349,19 +350,36 @@ describe('getSubject', () => {
 describe('getLogFormat', () => {
   it('returns modern format', async () => {
     mock('getGitVersion', () => Promise.resolve('1.7.2'))
-    expect(await getLogFormat()).to.equal('__AUTO_CHANGELOG_COMMIT_SEPARATOR__%H%n%d%n%ai%n%an%n%ae%n%B__AUTO_CHANGELOG_MESSAGE_SEPARATOR__')
+    const options = { mercurialCompat: false }
+    expect(await getLogFormat(options)).to.equal('__AUTO_CHANGELOG_COMMIT_SEPARATOR__%H%n%d%n%ai%n%an%n%ae%n%B__AUTO_CHANGELOG_MESSAGE_SEPARATOR__')
     unmock('cmd')
   })
 
   it('returns fallback format', async () => {
     mock('getGitVersion', () => Promise.resolve('1.7.1'))
-    expect(await getLogFormat()).to.equal('__AUTO_CHANGELOG_COMMIT_SEPARATOR__%H%n%d%n%ai%n%an%n%ae%n%s%n%n%b__AUTO_CHANGELOG_MESSAGE_SEPARATOR__')
+    const options = { mercurialCompat: false }
+    expect(await getLogFormat(options)).to.equal('__AUTO_CHANGELOG_COMMIT_SEPARATOR__%H%n%d%n%ai%n%an%n%ae%n%s%n%n%b__AUTO_CHANGELOG_MESSAGE_SEPARATOR__')
     unmock('cmd')
   })
 
   it('returns fallback format when null', async () => {
     mock('getGitVersion', () => Promise.resolve(null))
-    expect(await getLogFormat()).to.equal('__AUTO_CHANGELOG_COMMIT_SEPARATOR__%H%n%d%n%ai%n%an%n%ae%n%s%n%n%b__AUTO_CHANGELOG_MESSAGE_SEPARATOR__')
+    const options = { mercurialCompat: false }
+    expect(await getLogFormat(options)).to.equal('__AUTO_CHANGELOG_COMMIT_SEPARATOR__%H%n%d%n%ai%n%an%n%ae%n%s%n%n%b__AUTO_CHANGELOG_MESSAGE_SEPARATOR__')
+    unmock('cmd')
+  })
+
+  it('returns modern Hg format', async () => {
+    mock('getHgVersion', () => Promise.resolve('2.4.0'))
+    const options = { mercurialCompat: true }
+    expect(await getLogFormat(options)).to.equal(`__AUTO_CHANGELOG_COMMIT_SEPARATOR__{node}\n{if(tags,\' (tag: {tags})\n\',\'\n\')}{date|isodate}\n{author|person}\n{author|email}\n{desc}\n__AUTO_CHANGELOG_MESSAGE_SEPARATOR__\n {files|count} files changed, 0 insertions(+), 0 deletions(-)\n\n`)
+    unmock('cmd')
+  })
+
+  it('returns fallback format', async () => {
+    mock('getHgVersion', () => Promise.resolve('2.3.2'))
+    const options = { mercurialCompat: true }
+    expect(await getLogFormat(options)).to.equal(`__AUTO_CHANGELOG_COMMIT_SEPARATOR__{node}\n (tag: {tags})\n{date|isodate}\n{author|person}\n{author|email}\n{desc}\n__AUTO_CHANGELOG_MESSAGE_SEPARATOR__\n 0 files changed, 0 insertions(+), 0 deletions(-)\n\n`)
     unmock('cmd')
   })
 })


### PR DESCRIPTION
Do you see an interest in adding a (partial) compatibility mode with mercurial?
I sometimes have to work on older Hg repos and would like to be able to generate changelogs for them, too.

Basically, the core of this commit is a format for "hg log" allowing its output to be parsed by the existing code.

Tests should be added to this PR before merging, but first I would like to have your opinion on whether you think it is worth it.