### PR TITLE
fix parsing of --issue-url and -i options

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -35,7 +35,7 @@ async function getOptions (argv) {
     .option('-l, --commit-limit <count>', `number of commits to display per release, default: ${DEFAULT_OPTIONS.commitLimit}`, parseLimit)
     .option('-b, --backfill-limit <count>', `number of commits to backfill empty releases with, default: ${DEFAULT_OPTIONS.backfillLimit}`, parseLimit)
     .option('--commit-url <url>', 'override url for commits, use {id} for commit id')
-    .option('--issue-url, -i <url>', 'override url for issues, use {id} for issue id') // -i kept for back compatibility
+    .option('-i, --issue-url <url>', 'override url for issues, use {id} for issue id') // -i kept for back compatibility
     .option('--merge-url <url>', 'override url for merges, use {id} for merge id')
     .option('--compare-url <url>', 'override url for compares, use {from} and {to} for tags')
     .option('--issue-pattern <regex>', 'override regex pattern for issues in commit messages')

--- a/test/run.js
+++ b/test/run.js
@@ -23,6 +23,16 @@ describe('getOptions', () => {
     const options = await getOptions(['', '', '--commit-limit', 'false'])
     expect(options.commitLimit).to.equal(false)
   })
+
+  it('parses --issue-url correctly when given --issue-url', async () => {
+    const options = await getOptions(['', '', '--issue-url', 'https://test.issue.local/issues/{id}'])
+    expect(options.issueUrl).to.equal('https://test.issue.local/issues/{id}')
+  })
+
+  it('parses -i correctly when given -i', async () => {
+    const options = await getOptions(['', '', '-i', 'https://test.issue.local/issues/{id}'])
+    expect(options.issueUrl).to.equal('https://test.issue.local/issues/{id}')
+  })
 })
 
 describe('run', () => {


### PR DESCRIPTION
The order of the option setup is important. The resulting object was placing the override in `I` instead of the expected `issueUrl` slot.

This change corrects the option to restore the `--issue-url` override (while preserving the -i option).

I have also added a simple test case to protect you from future regressions.