### PR TITLE
fix(dependencies): handlebars < 4.3.0 is vulnerable

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "commander": "^3.0.1",
     "core-js": "^3.2.1",
-    "handlebars": "^4.1.2",
+    "handlebars": "^4.3.5",
     "lodash.uniqby": "^4.7.0",
     "node-fetch": "^2.6.0",
     "parse-github-url": "^1.0.2",


### PR DESCRIPTION
## Description
Upgraded handlebars dependency to > 4.3.0 because lower versions are vulnerable to Prototype Pollution leading to Remote Code Execution
This leads into security alerts in all repositories which are using the latest auto-changelog version

See https://github.com/advisories/GHSA-w457-6q6x-cgp9