### PR TITLE
add --prepend option as altenative to prepend-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
       --hide-credit                   # hide auto-changelog credit
       --handlebars-setup [file]       # handlebars setup file
       --append-git-log [string]       # string to append to git log command
+      --prepend                       # prepend changelog to output file
       --stdout                        # output changelog to stdout
   -V, --version                       # output the version number
   -h, --help                          # output usage information

--- a/src/run.js
+++ b/src/run.js
@@ -52,6 +52,7 @@ async function getOptions (argv) {
     .option('--handlebars-setup <file>', 'handlebars setup file')
     .option('--append-git-log <string>', 'string to append to git log command')
     .option('--stdout', 'output changelog to stdout')
+    .option('--prepend', 'prepend changelog to the start of the changelog file')
     .version(version)
     .parse(argv)
 
@@ -109,7 +110,12 @@ async function write (changelog, options, log) {
   const bytes = Buffer.byteLength(changelog, 'utf8')
   const existing = await fileExists(options.output) && await readFile(options.output, 'utf8')
   if (existing) {
-    const index = existing.indexOf(PREPEND_TOKEN)
+    let index = existing.indexOf(PREPEND_TOKEN)
+
+    if (index === -1 && options.prepend) {
+      index = 0;
+    }
+
     if (index !== -1) {
       const prepended = `${changelog}\n${existing.slice(index)}`
       await writeFile(options.output, prepended)

--- a/src/run.js
+++ b/src/run.js
@@ -51,8 +51,8 @@ async function getOptions (argv) {
     .option('--hide-credit', 'hide auto-changelog credit')
     .option('--handlebars-setup <file>', 'handlebars setup file')
     .option('--append-git-log <string>', 'string to append to git log command')
+    .option('--prepend', 'prepend changelog to output file')
     .option('--stdout', 'output changelog to stdout')
-    .option('--prepend', 'prepend changelog to the start of the changelog file')
     .version(version)
     .parse(argv)
 
@@ -110,12 +110,7 @@ async function write (changelog, options, log) {
   const bytes = Buffer.byteLength(changelog, 'utf8')
   const existing = await fileExists(options.output) && await readFile(options.output, 'utf8')
   if (existing) {
-    let index = existing.indexOf(PREPEND_TOKEN)
-
-    if (index === -1 && options.prepend) {
-      index = 0;
-    }
-
+    const index = options.prepend ? 0 : existing.indexOf(PREPEND_TOKEN)
     if (index !== -1) {
       const prepended = `${changelog}\n${existing.slice(index)}`
       await writeFile(options.output, prepended)


### PR DESCRIPTION
Hi, me again 👋 

Thanks again for answering my issue https://github.com/CookPete/auto-changelog/issues/165 so quickly, and with implementation no less 😱  

I noticed you implemented this idea of a "prepend token" which would make it quite challenging to automate the way that I'm hoping to 🤔  it means that after we make a release with a prepend token, we would need to move the prepend token to the top of the file again. Also if anyone forgets to do this while I'm not managing the project then they run the risk of deleting other people's changelogs.

I added a `--prepend` option that effectively acts like there is a prepend-token at the start of the file at all times. Let me know if you have any questions or if you need me to do anything else to get this merged