### PR TITLE
feat: add support for minor/preminor versions for custom templates

### DIFF
--- a/src/tags.js
+++ b/src/tags.js
@@ -68,6 +68,15 @@ const enrichTag = ({ getCompareLink, tagPattern }) => (t, index, tags) => {
       semver.valid(previous.version) &&
       semver.diff(t.version, previous.version) === 'major'
     ),
+    minor: Boolean(
+			previous &&
+			semver.valid(t.version) &&
+			semver.valid(previous.version) &&
+			(
+       semver.diff(t.version, previous.version) === "minor" ||
+       semver.diff(t.version, previous.version) === "preminor"
+      )
+		),
     ...t
   }
 }

--- a/src/tags.js
+++ b/src/tags.js
@@ -69,14 +69,11 @@ const enrichTag = ({ getCompareLink, tagPattern }) => (t, index, tags) => {
       semver.diff(t.version, previous.version) === 'major'
     ),
     minor: Boolean(
-			previous &&
-			semver.valid(t.version) &&
-			semver.valid(previous.version) &&
-			(
-       semver.diff(t.version, previous.version) === "minor" ||
-       semver.diff(t.version, previous.version) === "preminor"
-      )
-		),
+      previous &&
+      semver.valid(t.version) &&
+      semver.valid(previous.version) &&
+      ['minor', 'preminor'].includes(semver.diff(t.version, previous.version))
+    ),
     ...t
   }
 }


### PR DESCRIPTION
hey there, 

i have added minor version support for custom templates, so that the custom templates could use it to differentiate and show accordingly (for eg font size diff for patch and minor and major) ,

kindly take a look, 
thanks,