### PR TITLE
Feat: add sortCommits by subject and subject-desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Options:
       --tag-pattern [regex]           # override regex pattern for version tags
       --tag-prefix [prefix]           # prefix used in version tags, default: v
       --starting-version [tag]        # specify earliest version to include in changelog
-      --sort-commits [property]       # sort commits by property [relevance, date, date-desc], default: relevance
+      --sort-commits [property]       # sort commits by property [relevance, date, date-desc, subject, subject-desc], default: relevance
       --release-summary               # display tagged commit message body as release summary
       --unreleased-only               # only output unreleased changes
       --hide-credit                   # hide auto-changelog credit

--- a/src/releases.js
+++ b/src/releases.js
@@ -60,6 +60,8 @@ const sortCommits = ({ sortCommits }) => (a, b) => {
   if (a.breaking && !b.breaking) return -1
   if (sortCommits === 'date') return new Date(a.date) - new Date(b.date)
   if (sortCommits === 'date-desc') return new Date(b.date) - new Date(a.date)
+  if (sortCommits === 'subject') return a.subject.localeCompare(b.subject)
+  if (sortCommits === 'subject-desc') return b.subject.localeCompare(a.subject)
   return (b.insertions + b.deletions) - (a.insertions + a.deletions)
 }
 


### PR DESCRIPTION
Thanks a lot for your works ! 
Inside our project we use a prefix to categorize our commits. 
In order to group them, we would like to sort it by subject.