### PR TITLE
Add Template for handling commits with Conventional Commits format

### DIFF
--- a/templates/conventionalcommits.hbs
+++ b/templates/conventionalcommits.hbs
@@ -1,0 +1,133 @@
+## Changelog
+
+{{!--
+Introduction
+• This template tries to follow conventional commits format https://www.conventionalcommits.org/en/v1.0.0/
+• The template uses regex to filter commit types into their own headings (this is more than just fixes and features headings)
+• It also uses the replaceText function in package.json to remove the commit type text from the message, because the headers are shown instead.
+
+• The text 'Breaking:' or 'Breaking changes:' can be located anywhere in the commit.
+• The types feat:, fix:, chore:, docs:, refactor:, test:, style:, perf: must be at the beginning of the commit subject with an : on end.
+   • They can optionally have a scope set to outline the module or component that is affected eg feat(bldAssess):
+
+Example Definitions
+• feat: A new feature
+• fix: A bug fix
+• perf: A code change that improves performance
+• refactor: A code change that neither fixes a bug nor adds a feature
+• style: Changes that do not affect the meaning of the code (white-space, formatting, spelling mistakes, missing semi-colons, etc)
+• test: Adding missing tests or correcting existing tests
+• docs: Adding/updating documentation
+• chore: Something like updating a library version, or moving files to be in a better location and updating all file refs
+--}}
+
+
+{{!-- In package.json need to add this to remove label text from the change log output (becuase the markdown headers are now used to group them).
+   NOTES • Individual brackets have been escaped twice to be Json compliant.
+         • For items that define a scope eg feat(bldAssess): We remove the 1st bracket and then re-add it so we can select the right piece of text
+{
+  "name": "my-awesome-package",
+
+  "auto-changelog": {
+    "replaceText": {
+      "([bB]reaking:)": "",
+      "([bB]reaking change:)": "",
+      "(^[fF]eat:)": "",
+      "(^[fF]eat\\()": "\\(",
+      "(^[fF]ix:)": "",
+      "(^[fF]ix\\()": "\\(",
+      "(^[cC]hore:)": "",
+      "(^[cC]hore\\()": "\\(",
+      "(^[dD]ocs:)": "",
+      "(^[dD]ocs\\()": "\\(",
+      "(^[rR]efactor:)": "",
+      "(^[rR]efactor\\()": "\\(",
+      "(^[tT]est:)": "",
+      "(^[tT]est\\()": "\\(",
+      "(^[sS]tyle:)": "",
+      "(^[sS]tyle\\()": "\\(",
+      "(^[pP]erf:)": "",
+      "(^[pP]erf\\()": "\\("
+    }
+  }
+
+}
+ --}}
+
+ {{!--
+ Regex reminders
+ ^ = starts with
+ \( = ( character (otherwise it is interpreted as a regex lookup group)
+ * = zero or more of the previous character
+ \s = whitespace
+ . = any character except newline
+ | = or
+ [aA] = charcter a or character A
+ --}}
+
+
+{{#each releases}}
+  {{#if href}}
+    ##{{#unless major}}#{{/unless}} [{{title}}]({{href}}) - {{#if tag}} {{niceDate}} {{/if}}
+
+  {{else}}
+    ### {{title}}
+  {{/if}}
+
+
+  {{#if summary}}
+    {{summary}}
+  {{/if}}
+
+  {{#each merges}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}}
+  {{/each}}
+
+  {{#each fixes}}
+    - {{#if commit.breaking}}**Breaking change:** {{/if}}{{commit.subject}}{{#each fixes}}{{/each}}
+  {{/each}}
+
+
+  {{! List commits with 'breaking:' or 'Breaking change:' anywhere in the message under a heading}}
+  {{#commit-list commits heading='#### Breaking Changes :warning:' message='[bB]reaking [cC]hange:|[bB]reaking:' }}
+    - {{subject}} @{{author}}  <!--[`{{shorthash}}`]({{href}}) -->
+  {{/commit-list}}
+
+  {{! List commits organised under a heading, but not those already listed in the breaking section }}
+      {{#commit-list commits heading='#### New Features' message='^[fF]eat:|[fF]eat\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Fixes' message='^[fF]ix:|^[fF]ix\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Chores And Housekeeping' message='^[cC]hore:|^[cC]hore\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Documentation Changes' message='^[dD]ocs:|^[dD]ocs\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Refactoring and Updates' message='^[rR]efactor:|^[rR]efactor\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Changes to Test Assests' message='^[tT]est:|^[tT]est\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Tidying of Code eg Whitespace' message='^[sS]tyle:|^[sS]tyle\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### Performance Improvments' message='^[pP]erf:|^[pP]erf\(' exclude='[bB]reaking [cC]hange:|[bB]reaking:'}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+      {{#commit-list commits heading='#### General Changes' exclude='[bB]reaking [cC]hange:|[bB]reaking:|^[fF]eat:|^[fF]eat\(|^[fF]ix:|^[fF]ix\(|^[cC]hore:|^[cC]hore\(|^[dD]ocs:|^[dD]ocs\(|^[rR]efactor:|^[rR]efactor\(|^[tT]est:|^[tT]est\(|^[sS]tyle:|^[sS]tyle\(|^[pP]erf:|^[pP]erf\('}}
+        - {{subject}} @{{author}}
+      {{/commit-list}}
+
+{{/each}}


### PR DESCRIPTION
This template will organise commits into their own headings for each version using the Conventional Commits/Angular format as explained here https://www.conventionalcommits.org/en/v1.0.0/

Comments have been deliberately left in the template to 

- Help explain the logic of the template, including which commit types are supported
- Provide some extra support for new users who may want to customise things.  
- Include the Regex code for package.json to allow users to instantly start using the template
- I'd request that these comments are not stripped out as they are obviously not included in the final change log and don't really hurt anyone.
- This template also deliberately does not include a link to the individual commits to reduce the file size (due to limitation on some platforms that only allow - for example - 5000 characters in a change log submitted with a build). Users can easily add this back in using the other 3 templates of the repo as inspiration if needed.