### PR TITLE
Trim commit subject

### DIFF
--- a/src/commits.js
+++ b/src/commits.js
@@ -65,7 +65,7 @@ const getSubject = (message) => {
   if (!message.trim()) {
     return '_No commit message_'
   }
-  return message.match(/[^\n]+/)[0]
+  return message.match(/[^\n]+/)[0].trim()
 }
 
 const getStats = (stats) => {

--- a/test/commits.js
+++ b/test/commits.js
@@ -311,7 +311,7 @@ describe('getMerge', () => {
 
 describe('getSubject', () => {
   it('returns commit subject', () => {
-    const message = 'Commit message\n\nCloses ABC-1234'
+    const message = ' Commit message\n\nCloses ABC-1234'
     expect(getSubject(message)).to.equal('Commit message')
   })
 


### PR DESCRIPTION
Since, we shouldn't have extra spaces before and after changelog entries, I've added a call to `trim()` in the commit subject extraction function.