### PR TITLE
Fixes #221: logical handling of --starting-version

### DIFF
--- a/test/tags.js
+++ b/test/tags.js
@@ -104,7 +104,13 @@ describe('fetchTags', () => {
   })
 
   it('supports --starting-version', async () => {
-    expect(await fetchTags({ ...options, startingVersion: 'v0.2.2' })).to.have.lengthOf(3)
+    expect(await fetchTags({ ...options, startingVersion: 'v0.3' })).to.have.lengthOf(2)
+    // abreviated tag inferred via semver
+    expect(await fetchTags({ ...options, startingVersion: 'v1' })).to.have.lengthOf(1)
+    // inexistant tag in the past
+    expect(await fetchTags({ ...options, startingVersion: 'v0.2.8' })).to.have.lengthOf(2)
+    // inexistant tag in the future
+    expect(await fetchTags({ ...options, startingVersion: 'v2.0.0' })).to.have.lengthOf(0)
   })
 
   it('supports --ending-version', async () => {

--- a/test/tags.js
+++ b/test/tags.js
@@ -105,12 +105,9 @@ describe('fetchTags', () => {
 
   it('supports --starting-version', async () => {
     expect(await fetchTags({ ...options, startingVersion: 'v0.3' })).to.have.lengthOf(2)
-    // abreviated tag inferred via semver
-    expect(await fetchTags({ ...options, startingVersion: 'v1' })).to.have.lengthOf(1)
-    // inexistant tag in the past
-    expect(await fetchTags({ ...options, startingVersion: 'v0.2.8' })).to.have.lengthOf(2)
-    // inexistant tag in the future
-    expect(await fetchTags({ ...options, startingVersion: 'v2.0.0' })).to.have.lengthOf(0)
+    expect(await fetchTags({ ...options, startingVersion: 'v1' })).to.have.lengthOf(1) // Inferred semver
+    expect(await fetchTags({ ...options, startingVersion: 'v0.2.8' })).to.have.lengthOf(2) // Non-existent tag from the past
+    expect(await fetchTags({ ...options, startingVersion: 'v2.0.0' })).to.have.lengthOf(0) // Non-existent tag from the future
   })
 
   it('supports --ending-version', async () => {


### PR DESCRIPTION
- Pads semver tags passed to `--starting-version` with `0`'s so one can now specify `--starting-version v1` which will expand to `v1.0.0`, but would previously include all tags in the changelog
- Allows inexistant tags to be specified: if the version is superior to any existing tag, the changelog will be empty. If the version is inferior to an existing tag, it will include all versions logically above the inexistant tag