### PR TITLE
Fix: gitlab subgroups

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -27,7 +27,6 @@ const getRemote = (remoteURL, options = {}) => {
 
   const IS_BITBUCKET = /bitbucket/.test(hostname)
   const IS_GITLAB = /gitlab/.test(hostname)
-  const IS_GITLAB_SUBGROUP = /\.git$/.test(remote.branch)
   const IS_AZURE = /dev\.azure/.test(hostname)
   const IS_VISUAL_STUDIO = /visualstudio/.test(hostname)
 
@@ -43,9 +42,7 @@ const getRemote = (remoteURL, options = {}) => {
   }
 
   if (IS_GITLAB) {
-    const url = IS_GITLAB_SUBGROUP
-      ? `${protocol}//${hostname}/${remote.repo}/${remote.branch.replace(/\.git$/, '')}`
-      : `${protocol}//${hostname}/${remote.repo}`
+    const url = `${protocol}//${hostname}/${remote.pathname.replace(/git@.*:/, '').replace(/\.git$/, '')}`
     return {
       getCommitLink: id => `${url}/commit/${id}`,
       getIssueLink: id => `${url}/issues/${id}`,

--- a/test/remote.js
+++ b/test/remote.js
@@ -57,6 +57,18 @@ const TEST_DATA = [
   },
   {
     remotes: [
+      'https://gitlab.com/user/repo/group/repo.git',
+      'git@gitlab.com:user/repo/group/repo.git'
+    ],
+    expected: {
+      commit: 'https://gitlab.com/user/repo/group/repo/commit/123',
+      issue: 'https://gitlab.com/user/repo/group/repo/issues/123',
+      merge: 'https://gitlab.com/user/repo/group/repo/merge_requests/123',
+      compare: 'https://gitlab.com/user/repo/group/repo/compare/v1.2.3...v2.0.0'
+    }
+  },
+  {
+    remotes: [
       'https://bitbucket.org/user/repo',
       'git@bitbucket.org:user/repo.git'
     ],


### PR DESCRIPTION
Fix when you have more than one subgroup like https://gitlab.com/user/group/subgroup_1/subgroup_2/repo.git

Refs: #93 