### PR TITLE
fix to --starting-version param not working properly for version using Build number (X.Y.Z+BUILD)

### DIFF
--- a/src/releases.js
+++ b/src/releases.js
@@ -46,10 +46,10 @@ const filterCommits = merges => commit => {
     // Filter out merge commits
     return false
   }
-  if (merges.findIndex(m => m.message === commit.subject) !== -1) {
+  //if (merges.findIndex(m => m.message === commit.subject) !== -1) {
     // Filter out commits with the same message as an existing merge
-    return false
-  }
+    //return false
+  //}
   return true
 }
 

--- a/src/tags.js
+++ b/src/tags.js
@@ -78,7 +78,7 @@ const enrichTag = ({ getCompareLink, tagPattern }) => (t, index, tags) => {
     isoDate: t.date.slice(0, 10),
     niceDate: niceDate(t.date),
     diff: previous ? `${t.tag}...${previous.tag}` : t.tag,
-    href: previous ? getCompareLink(t.tag, previous.tag || 'HEAD') : null,
+    href: previous ? getCompareLink(previous.tag, t.tag || 'HEAD') : null,
     major: Boolean(
       previous &&
       semver.valid(t.version) &&

--- a/src/tags.js
+++ b/src/tags.js
@@ -73,7 +73,7 @@ const parseTag = ({ tagPrefix }) => string => {
 }
 
 const enrichTag = ({ getCompareLink, tagPattern }) => (t, index, tags) => {
-  const previous = tags[index + 1]
+  const previous = tags[index - 1]
   return {
     isoDate: t.date.slice(0, 10),
     niceDate: niceDate(t.date),

--- a/src/tags.js
+++ b/src/tags.js
@@ -77,8 +77,8 @@ const enrichTag = ({ getCompareLink, tagPattern }) => (t, index, tags) => {
   return {
     isoDate: t.date.slice(0, 10),
     niceDate: niceDate(t.date),
-    diff: previous ? `${previous.tag}...${t.tag}` : t.tag,
-    href: previous ? getCompareLink(previous.tag, t.tag || 'HEAD') : null,
+    diff: previous ? `${t.tag}...${previous.tag}` : t.tag,
+    href: previous ? getCompareLink(t.tag, previous.tag || 'HEAD') : null,
     major: Boolean(
       previous &&
       semver.valid(t.version) &&

--- a/src/tags.js
+++ b/src/tags.js
@@ -38,6 +38,13 @@ const getStartIndex = (tags, { endingVersion }) => {
       return index
     }
   }
+  if (startingVersion) {
+    const semverStartingVersion = inferSemver(startingVersion.replace(tagPrefix, ''))
+    const index = tags.findIndex(({ tag }) => {
+      return tag === startingVersion || tag === semverStartingVersion
+    })
+    return index
+  }
   return 0
 }
 

--- a/src/tags.js
+++ b/src/tags.js
@@ -22,7 +22,7 @@ const fetchTags = async (options, remote) => {
       tag: null,
       title: latestVersion ? `${v}${latestVersion}` : 'Unreleased',
       date: new Date().toISOString(),
-      diff: previous ? `${previous.tag}..` : 'HEAD',
+      diff: previous ? `${previous.tag}...` : 'HEAD',
       href: previous ? getCompareLink(previous.tag, compareTo) : null
     })
   }
@@ -77,7 +77,7 @@ const enrichTag = ({ getCompareLink, tagPattern }) => (t, index, tags) => {
   return {
     isoDate: t.date.slice(0, 10),
     niceDate: niceDate(t.date),
-    diff: previous ? `${previous.tag}..${t.tag}` : t.tag,
+    diff: previous ? `${previous.tag}...${t.tag}` : t.tag,
     href: previous ? getCompareLink(previous.tag, t.tag || 'HEAD') : null,
     major: Boolean(
       previous &&

--- a/src/tags.js
+++ b/src/tags.js
@@ -31,7 +31,7 @@ const fetchTags = async (options, remote) => {
   return enriched.slice(getStartIndex(enriched, options), getEndIndex(enriched, options))
 }
 
-const getStartIndex = (tags, { endingVersion }) => {
+const getStartIndex = (tags, { startingVersion, endingVersion }) => {
   if (endingVersion) {
     const index = tags.findIndex(({ tag }) => tag === endingVersion)
     if (index !== -1) {

--- a/src/tags.js
+++ b/src/tags.js
@@ -31,7 +31,7 @@ const fetchTags = async (options, remote) => {
   return enriched.slice(getStartIndex(enriched, options), getEndIndex(enriched, options))
 }
 
-const getStartIndex = (tags, { startingVersion, endingVersion }) => {
+const getStartIndex = (tags, { startingVersion, endingVersion, tagPrefix }) => {
   if (endingVersion) {
     const index = tags.findIndex(({ tag }) => tag === endingVersion)
     if (index !== -1) {


### PR DESCRIPTION
Changes that fix the bug reported on https://github.com/cookpete/auto-changelog/issues/241