### PR TITLE
Fix bad URL for GitLab remotes with multiple sub-groups

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -27,7 +27,6 @@ const getRemote = (remoteURL, options = {}) => {
 
   const IS_BITBUCKET = /bitbucket/.test(hostname)
   const IS_GITLAB = /gitlab/.test(hostname)
-  const IS_GITLAB_SUBGROUP = /\.git$/.test(remote.branch)
   const IS_AZURE = /dev\.azure/.test(hostname)
   const IS_VISUAL_STUDIO = /visualstudio/.test(hostname)
 
@@ -43,9 +42,8 @@ const getRemote = (remoteURL, options = {}) => {
   }
 
   if (IS_GITLAB) {
-    const url = IS_GITLAB_SUBGROUP
-      ? `${protocol}//${hostname}/${remote.repo}/${remote.branch.replace(/\.git$/, '')}`
-      : `${protocol}//${hostname}/${remote.repo}`
+    const path = remoteURL.match(/.*gitlab.com(?::|\/)([^.]*)(?:\.git)?/)[1]
+    const url = `${protocol}//${hostname}/${path}`
     return {
       getCommitLink: id => `${url}/commit/${id}`,
       getIssueLink: id => `${url}/issues/${id}`,

--- a/test/remote.js
+++ b/test/remote.js
@@ -57,6 +57,19 @@ const TEST_DATA = [
   },
   {
     remotes: [
+      'https://gitlab.com/organisation/group/subgroup/repo',
+      'https://gitlab.com/organisation/group/subgroup/repo.git',
+      'git@gitlab.com:organisation/group/subgroup/repo.git'
+    ],
+    expected: {
+      commit: 'https://gitlab.com/organisation/group/subgroup/repo/commit/123',
+      issue: 'https://gitlab.com/organisation/group/subgroup/repo/issues/123',
+      merge: 'https://gitlab.com/organisation/group/subgroup/repo/merge_requests/123',
+      compare: 'https://gitlab.com/organisation/group/subgroup/repo/compare/v1.2.3...v2.0.0'
+    }
+  },
+  {
+    remotes: [
       'https://bitbucket.org/user/repo',
       'git@bitbucket.org:user/repo.git'
     ],


### PR DESCRIPTION
Hey!

I've noticed an issue when using a GitLab project with several sub-groups: only the first group is matched, and the other groups and the project name is discarded.

I've added test cases reproducing the issues and a proposed fix. As the `parse-github-url` method discarded completely some parts of the source URL, I've opted to re-parse it for GitLab with a regexp. I don't think this is a great from a maintainability standpoint, but I am unsure how to implement this differently

Let me know what you think!