### PR TITLE
add regex flags option

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const { spawn } = require('child_process')
 
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+const REGEX_FLAGS = new Set(["g", "i", "m", "d", "s", "u", "y"])
 
 const updateLog = (string, clearLine = true) => {
   if (clearLine) {
@@ -67,7 +68,7 @@ const replaceText = (string, options) => {
     return string
   }
   if (options.flags && typeof options.flags === 'string') {
-    defaultFlags = filterRegexFlags(defaultFlags.concat(String(options.flags)));
+    defaultFlags = filterRegexFlags(defaultFlags + options.flags);
   }
   return Object.keys(options.replaceText).reduce((string, pattern) => {
     return string.replace(new RegExp(pattern, defaultFlags), options.replaceText[pattern])
@@ -106,10 +107,9 @@ const readJson = async (path) => {
 
 const filterRegexFlags = (flags) => {
   const finalFlags = new Set()
-  let mainFlags = ["g", "i", "m", "d", "s", "u", "y"]
 
   flags.split("").forEach((item) => {
-    if (mainFlags.includes(item)) {
+    if (REGEX_FLAGS.has(item)) {
       finalFlags.add(item)
     }
   })

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,11 +61,16 @@ const encodeHTML = (string) => {
 }
 
 const replaceText = (string, options) => {
+  let defaultFlags = 'g'
+
   if (!options.replaceText) {
     return string
   }
+  if (options.flags && typeof options.flags === 'string') {
+    defaultFlags = filterRegexFlags(defaultFlags.concat(String(options.flags)));
+  }
   return Object.keys(options.replaceText).reduce((string, pattern) => {
-    return string.replace(new RegExp(pattern, 'g'), options.replaceText[pattern])
+    return string.replace(new RegExp(pattern, defaultFlags), options.replaceText[pattern])
   }, string)
 }
 
@@ -99,6 +104,20 @@ const readJson = async (path) => {
   return JSON.parse(await readFile(path))
 }
 
+const filterRegexFlags = (flags) => {
+  const finalFlags = new Set()
+  let mainFlags = ["g", "i", "m", "d", "s", "u", "y"]
+
+  flags.split("").forEach((item) => {
+    if (mainFlags.includes(item)) {
+      finalFlags.add(item)
+    }
+  })
+
+  return Array.from(finalFlags).join("")
+}
+
+
 module.exports = {
   updateLog,
   formatBytes,
@@ -112,5 +131,6 @@ module.exports = {
   readFile,
   writeFile,
   fileExists,
-  readJson
+  readJson,
+  filterRegexFlags
 }

--- a/test/commits.js
+++ b/test/commits.js
@@ -65,6 +65,19 @@ describe('parseCommits', () => {
     const result = parseCommits(gitLog, options)
     expect(result.filter(c => c.subject === 'Some **BREAKING** change')).to.have.length(1)
   })
+
+  it('supports regex flags option', async () => {
+    const gitLog = await readFile(join(__dirname, 'data', 'git-log.txt'))
+    const options = {
+      replaceText: {
+        BREAKING: '**BREAKING**'
+      },
+      flags: "i",
+      ...remotes.github
+    }
+    const result = parseCommits(gitLog, options)
+    expect(result.filter(c => c.subject === 'Some **BREAKING** change')).to.have.length(1)
+  })
 })
 
 describe('getFixes', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,6 +10,7 @@ const {
   writeFile,
   fileExists,
   readJson,
+  filterRegexFlags,
   __Rewire__: mock,
   __ResetDependency__: unmock
 } = require('../src/utils')
@@ -101,5 +102,17 @@ describe('readJson', () => {
     })
     expect(await readJson()).to.deep.equal({ abc: 123 })
     unmock('fs')
+  })
+})
+
+describe('filterRegexFlags', () => {
+  it('filter available input regex flags', () => {
+    expect(filterRegexFlags('i')).to.equal('i')
+    expect(filterRegexFlags('gi')).to.equal('gi')
+  })
+
+  it('filter unavailable input regex flags', () => {
+    expect(filterRegexFlags('ixyz')).to.equal('iy')
+    expect(filterRegexFlags('gixyzm')).to.equal('giym')
   })
 })


### PR DESCRIPTION
when we want to replace a text, it is very useful to be able to use the flags of a regex, for example to use insensitive case


` new RegExp('pattern', 'flags');`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags


```
{
  "name": "my-awesome-package",
  "auto-changelog": {
    "replaceText": {
      "(ABC-\\d+)": "[`$1`](https://issues.apache.org/jira/browse/$1)"
    },
    "flags": "i"
  }
}
```