### PR TITLE
Metadata feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ To see exactly what data is passed in to the templates, you can generate a JSON 
 ```bash
 auto-changelog --template json --output changelog-data.json
 ```
+#### templates metadata
+
+The metadata option set to true (by default false) allows you to get the information from `git config -l` and the information from `package.json`, which can be accessed from the metadata object in the template.
+
+```js
+{
+  "name": "my-awesome-package",
+  "auto-changelog": {
+    "metadata": true
+    }
+  }
+}
+```
+
 
 #### `commit-list` helper
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "commander": "^7.2.0",
     "handlebars": "^4.7.7",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "parse-github-url": "^1.0.2",
     "semver": "^7.3.5"

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -3,7 +3,7 @@ const { cmd, dotNotationToObject, readJson, niceDate } = require('./utils')
 
 const DIVIDER = '=';
 
-const getGitConfig = async () => {
+const fetchGitConfig = async () => {
     const config = (await cmd(`git config -l`))
 
     return config
@@ -17,14 +17,12 @@ const getGitConfig = async () => {
 }
 
 const getMetadata = async (options) => {
-    console.log("rree--->", options.metadata)
-
-    if (!options.metadata) {
-        return null
+    if (options.metadata !== true) {
+        return {}
     }
 
     const PACKAGE_FILE = 'package.json'
-    const config = await getGitConfig();
+    const config = await fetchGitConfig();
 
     const pkg = await readJson(PACKAGE_FILE)
 

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,0 +1,44 @@
+const merge = require('lodash/merge');
+const { cmd, dotNotationToObject, readJson, niceDate } = require('./utils')
+
+const DIVIDER = '=';
+
+const getGitConfig = async () => {
+    const config = (await cmd(`git config -l`))
+
+    return config
+        .trim()
+        .split('\n')
+        .reduce((acum, item) => {
+            const [key, value] = item.split(DIVIDER)
+            return merge(acum, dotNotationToObject(key, value))
+        }, {})
+
+}
+
+const getMetadata = async (options) => {
+    console.log("rree--->", options.metadata)
+
+    if (!options.metadata) {
+        return null
+    }
+
+    const PACKAGE_FILE = 'package.json'
+    const config = await getGitConfig();
+
+    const pkg = await readJson(PACKAGE_FILE)
+
+    const allowed = ['name', 'version', 'description', 'changos', 'keywords']
+
+    const meta = {};
+    allowed.forEach(element => {
+        meta[element] = pkg[element];
+    });
+
+    return JSON.parse(JSON.stringify({ now: niceDate(new Date()), ...meta, ...config }))
+
+}
+
+module.exports = {
+    getMetadata
+}

--- a/src/run.js
+++ b/src/run.js
@@ -4,7 +4,8 @@ const { fetchRemote } = require('./remote')
 const { fetchTags } = require('./tags')
 const { parseReleases } = require('./releases')
 const { compileTemplate } = require('./template')
-const { parseLimit, readFile, readJson, writeFile, fileExists, updateLog, formatBytes } = require('./utils')
+const { getMetadata } = require('./metadata')
+const { parseLimit, readFile, readJson, writeFile, fileExists, updateLog, formatBytes, niceDate, cmd } = require('./utils')
 
 const DEFAULT_OPTIONS = {
   output: 'CHANGELOG.md',
@@ -98,11 +99,15 @@ const run = async argv => {
   const options = await getOptions(argv)
   const log = string => options.stdout ? null : updateLog(string)
   log('Fetching tags…')
-  const tags = await fetchTags(options)
+  const tags = await fetchTags(options, options)
+  log('Fetching metadata…')
+  const metadata = await getMetadata(options)
+  console.log('!--->', metadata, options)
   log(`${tags.length} version tags found…`)
   const onParsed = ({ title }) => log(`Fetched ${title}…`)
   const releases = await parseReleases(tags, options, onParsed)
-  const changelog = await compileTemplate(releases, options)
+  console.log("OPTI", releases, options)
+  const changelog = await compileTemplate(releases, metadata, options)
   await write(changelog, options, log)
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -102,11 +102,9 @@ const run = async argv => {
   const tags = await fetchTags(options, options)
   log('Fetching metadata…')
   const metadata = await getMetadata(options)
-  console.log('!--->', metadata, options)
   log(`${tags.length} version tags found…`)
   const onParsed = ({ title }) => log(`Fetched ${title}…`)
   const releases = await parseReleases(tags, options, onParsed)
-  console.log("OPTI", releases, options)
   const changelog = await compileTemplate(releases, metadata, options)
   await write(changelog, options, log)
 }

--- a/src/template.js
+++ b/src/template.js
@@ -77,7 +77,7 @@ const cleanTemplate = template => {
     .replace(/\n\n$/, '\n')
 }
 
-const compileTemplate = async (releases, options) => {
+const compileTemplate = async (releases, metadata, options) => {
   const { template, handlebarsSetup } = options
   if (handlebarsSetup) {
     const path = /^\//.test(handlebarsSetup) ? handlebarsSetup : join(process.cwd(), handlebarsSetup)
@@ -88,9 +88,9 @@ const compileTemplate = async (releases, options) => {
   }
   const compile = Handlebars.compile(await getTemplate(template), COMPILE_OPTIONS)
   if (template === 'json') {
-    return compile({ releases, options })
+    return compile({ releases, metadata, options })
   }
-  return cleanTemplate(compile({ releases, options }))
+  return cleanTemplate(compile({ releases, metadata, options }))
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,6 +99,23 @@ const readJson = async (path) => {
   return JSON.parse(await readFile(path))
 }
 
+const dotNotationToObject = (str, value) => {
+  const props = str.split('.');
+  const last = props.pop()
+
+  let ref = {}
+  const object = ref;
+  props.forEach(prop => {
+    ref[prop] = {};
+    ref = ref[prop];
+  });
+
+  ref[last] = value;
+
+  return object
+}
+
+
 module.exports = {
   updateLog,
   formatBytes,
@@ -112,5 +129,6 @@ module.exports = {
   readFile,
   writeFile,
   fileExists,
-  readJson
+  readJson,
+  dotNotationToObject
 }

--- a/templates/metadata.hbs
+++ b/templates/metadata.hbs
@@ -1,0 +1,7 @@
+# {{metadata.name}} Changelog
+
+Description: {{metadata.description}}
+
+release date: {{metadata.now}}
+release owner name: {{metadata.user.name}}
+release owner email: {{metadata.user.email}}

--- a/test/data/metadata.js
+++ b/test/data/metadata.js
@@ -1,0 +1,10 @@
+module.exports = {
+  now: "20 January 2021",
+  version: "1.0.0",
+  name: "my-repository",
+  description: "description-repository",
+  user: { name: "John Doe", email: "John.Doe@domain.com" },
+  core: {
+    editor: "nano",
+  },
+};

--- a/test/data/template-metadata.md
+++ b/test/data/template-metadata.md
@@ -1,0 +1,7 @@
+# my-repository Changelog
+
+Description: description-repository
+
+release date: 20 January 2021
+release owner name: John Doe
+release owner email: John.Doe@domain.com

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,0 +1,54 @@
+const { describe, it, beforeEach, afterEach } = require("mocha");
+const { expect } = require("chai");
+
+const {
+  getMetadata,
+  __Rewire__: mock,
+  __ResetDependency__: unmock,
+} = require("../src/metadata");
+
+describe("metadata", () => {
+  beforeEach(() => {
+    mock("niceDate", () => "20 January 2021");
+    mock("fetchGitConfig", () => {
+      return {
+        user: { name: "John Doe", email: "John.Doe@domain.com" },
+        core: {
+          editor: "nano",
+        },
+      };
+    });
+    mock("readJson", () => {
+      return {
+        version: "1.0.0",
+        name: "my-repository",
+        description: "description-repository",
+      };
+    });
+  });
+
+  afterEach(() => {
+    unmock("niceDate");
+    unmock("readJson");
+    unmock("fetchGitConfig");
+  });
+
+  it("should return data from git config and package json if metadata option is true", async () => {   
+    expect(await getMetadata({ metadata: true })).to.deep.equal({
+      now: "20 January 2021",
+      version: "1.0.0",
+      name: "my-repository",
+      description: "description-repository",
+      user: { name: "John Doe", email: "John.Doe@domain.com" },
+      core: {
+        editor: "nano",
+      },
+    });
+  });
+
+  it("should return an empty object if metadata option is undefined or false", async () => {
+    expect(await getMetadata({})).to.deep.equal({});
+    expect(await getMetadata({metadata:false})).to.deep.equal({});
+    expect(await getMetadata({metadata: 'true'})).to.deep.equal({});
+  });
+});

--- a/test/template.js
+++ b/test/template.js
@@ -3,6 +3,7 @@ const { expect } = require('chai')
 const { join } = require('path')
 const { readFile } = require('../src/utils')
 const releases = require('./data/releases')
+const metadata = require('./data/metadata')
 const { compileTemplate } = require('../src/template')
 
 describe('compileTemplate', () => {
@@ -45,6 +46,13 @@ describe('compileTemplate', () => {
     expect(await compileTemplate(releases, {}, {
       template: path,
       handlebarsSetup: './test/data/handlebars-setup.js'
+    })).to.equal(expected)
+  })
+
+  it('compiles using metadata template', async () => {
+    const expected = await readFile(join(__dirname, 'data', 'template-metadata.md'))
+    expect(await compileTemplate(releases, metadata, {
+      template: 'metadata',
     })).to.equal(expected)
   })
 })

--- a/test/template.js
+++ b/test/template.js
@@ -8,33 +8,33 @@ const { compileTemplate } = require('../src/template')
 describe('compileTemplate', () => {
   it('compiles using compact template', async () => {
     const expected = await readFile(join(__dirname, 'data', 'template-compact.md'))
-    expect(await compileTemplate(releases, { template: 'compact' })).to.equal(expected)
+    expect(await compileTemplate(releases, {}, { template: 'compact' })).to.equal(expected)
   })
 
   it('compiles using keepachangelog template', async () => {
     const expected = await readFile(join(__dirname, 'data', 'template-keepachangelog.md'))
-    expect(await compileTemplate(releases, { template: 'keepachangelog' })).to.equal(expected)
+    expect(await compileTemplate(releases, {}, { template: 'keepachangelog' })).to.equal(expected)
   })
 
   it('compiles using json template', async () => {
     const expected = await readFile(join(__dirname, 'data', 'template-json.json'))
-    expect(await compileTemplate(releases, { template: 'json' })).to.equal(expected)
+    expect(await compileTemplate(releases, {}, { template: 'json' })).to.equal(expected)
   })
 
   it('compiles using path to template file', async () => {
     const path = join(__dirname, 'data', 'template-compact.md')
     const expected = await readFile(path)
-    expect(await compileTemplate(releases, { template: path })).to.equal(expected)
+    expect(await compileTemplate(releases, {}, { template: path })).to.equal(expected)
   })
 
   it('compiles using url path', async () => {
     const path = 'https://raw.githubusercontent.com/CookPete/auto-changelog/master/templates/compact.hbs'
     const expected = await readFile(join(__dirname, 'data', 'template-compact.md'))
-    expect(await compileTemplate(releases, { template: path })).to.equal(expected)
+    expect(await compileTemplate(releases, {}, { template: path })).to.equal(expected)
   }).timeout(10000)
 
   it('throws an error when no template found', done => {
-    compileTemplate(releases, { template: 'not-found' })
+    compileTemplate(releases, {}, { template: 'not-found' })
       .then(() => done('Should throw an error'))
       .catch(() => done())
   })
@@ -42,7 +42,7 @@ describe('compileTemplate', () => {
   it('supports handlebarsSetup option', async () => {
     const path = join(__dirname, 'data', 'template-custom-helper.md')
     const expected = await readFile(join(__dirname, 'data', 'template-custom-helper-compiled.md'))
-    expect(await compileTemplate(releases, {
+    expect(await compileTemplate(releases, {}, {
       template: path,
       handlebarsSetup: './test/data/handlebars-setup.js'
     })).to.equal(expected)

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,7 +11,8 @@ const {
   fileExists,
   readJson,
   __Rewire__: mock,
-  __ResetDependency__: unmock
+  __ResetDependency__: unmock,
+  dotNotationToObject
 } = require('../src/utils')
 
 describe('updateLog', () => {
@@ -101,5 +102,27 @@ describe('readJson', () => {
     })
     expect(await readJson()).to.deep.equal({ abc: 123 })
     unmock('fs')
+  })
+})
+
+describe('dotNotationToObject', () => {
+  it('create the object from a string', () => {
+    const dotString = 'user.name';
+    const value = 'John Doe'
+
+    const expected = {
+      user: {name: value}
+    }
+   
+    expect(dotNotationToObject(dotString, value)).to.deep.equal(expected)
+   
+  })
+
+    it('show error when parameter is not a string value', () => {
+    const dotString = 32
+    const value = 'John Doe'
+   
+    expect(()=> dotNotationToObject(dotString, value)).to.throw()
+   
   })
 })


### PR DESCRIPTION
On many occasions we want to be able to add general information to our changelog, and we can obtain that metadata from git config and from the package. In this case I would like to receive feedback to make this feature safe.

This would be a subset of information that we could obtain in metadata
```
{
      now: "20 January 2021",
      version: "1.0.0",
      name: "my-repository",
      description: "description-repository",
      user: { name: "John Doe", email: "John.Doe@domain.com" }
}
```

see template-metadata