### PR TITLE
Add support for GitLab's new style routes

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -47,10 +47,10 @@ const getRemote = (remoteURL, options = {}) => {
       ? `${protocol}//${hostname}/${remote.repo}/${remote.branch.replace(/\.git$/, '')}`
       : `${protocol}//${hostname}/${remote.repo}`
     return {
-      getCommitLink: id => `${url}/commit/${id}`,
-      getIssueLink: id => `${url}/issues/${id}`,
-      getMergeLink: id => `${url}/merge_requests/${id}`,
-      getCompareLink: (from, to) => `${url}/compare/${from}...${to}`,
+      getCommitLink: id => `${url}/-/commit/${id}`,
+      getIssueLink: id => `${url}/-/issues/${id}`,
+      getMergeLink: id => `${url}/-/merge_requests/${id}`,
+      getCompareLink: (from, to) => `${url}/-/compare/${from}...${to}`,
       ...overrides
     }
   }

--- a/test/commits.js
+++ b/test/commits.js
@@ -226,7 +226,7 @@ describe('getMerge', () => {
       expect(getMerge(EXAMPLE_COMMIT, message, remotes.gitlab)).to.deep.equal({
         id: '15007',
         message: 'Memoize GitLab logger to reduce open file descriptors',
-        href: 'https://gitlab.com/user/repo/merge_requests/15007',
+        href: 'https://gitlab.com/user/repo/-/merge_requests/15007',
         author: 'Commit Author',
         commit: EXAMPLE_COMMIT
       })
@@ -237,7 +237,7 @@ describe('getMerge', () => {
       expect(getMerge(EXAMPLE_COMMIT, message, remotes.gitlabSubgroup)).to.deep.equal({
         id: '15007',
         message: 'Memoize GitLab logger to reduce open file descriptors',
-        href: 'https://gitlab.com/user/repo/subgroup/merge_requests/15007',
+        href: 'https://gitlab.com/user/repo/subgroup/-/merge_requests/15007',
         author: 'Commit Author',
         commit: EXAMPLE_COMMIT
       })

--- a/test/remote.js
+++ b/test/remote.js
@@ -37,10 +37,10 @@ const TEST_DATA = [
       'git@gitlab.com:user/repo.git'
     ],
     expected: {
-      commit: 'https://gitlab.com/user/repo/commit/123',
-      issue: 'https://gitlab.com/user/repo/issues/123',
-      merge: 'https://gitlab.com/user/repo/merge_requests/123',
-      compare: 'https://gitlab.com/user/repo/compare/v1.2.3...v2.0.0'
+      commit: 'https://gitlab.com/user/repo/-/commit/123',
+      issue: 'https://gitlab.com/user/repo/-/issues/123',
+      merge: 'https://gitlab.com/user/repo/-/merge_requests/123',
+      compare: 'https://gitlab.com/user/repo/-/compare/v1.2.3...v2.0.0'
     }
   },
   {
@@ -49,10 +49,10 @@ const TEST_DATA = [
       'git@gitlab.com:user/repo/subgroup.git'
     ],
     expected: {
-      commit: 'https://gitlab.com/user/repo/subgroup/commit/123',
-      issue: 'https://gitlab.com/user/repo/subgroup/issues/123',
-      merge: 'https://gitlab.com/user/repo/subgroup/merge_requests/123',
-      compare: 'https://gitlab.com/user/repo/subgroup/compare/v1.2.3...v2.0.0'
+      commit: 'https://gitlab.com/user/repo/subgroup/-/commit/123',
+      issue: 'https://gitlab.com/user/repo/subgroup/-/issues/123',
+      merge: 'https://gitlab.com/user/repo/subgroup/-/merge_requests/123',
+      compare: 'https://gitlab.com/user/repo/subgroup/-/compare/v1.2.3...v2.0.0'
     }
   },
   {


### PR DESCRIPTION
This might be a breaking change for custom or self hosted Gitlab instances that are running old versions, as a solution they can use the override url options.