### PR TITLE
chore(templates): remove tabs in cleanTemplate

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -77,6 +77,7 @@ const cleanTemplate = template => {
   return template
     // Remove indentation
     .replace(/\n +/g, '\n')
+    .replace(/\t/g, '')
     .replace(/^ +/, '')
     // Fix multiple blank lines
     .replace(/\n\n\n+/g, '\n\n')


### PR DESCRIPTION
When using a custom handlebars template in project using tabs for indentation, the current output keeps indentation.

Adding a simple replacement in `cleanTemplate()` to drop `\t` does the trick.