### PR TITLE
Fix: Throws error if tag does not contains "version" property

### DIFF
--- a/src/tags.js
+++ b/src/tags.js
@@ -54,7 +54,7 @@ const getEndIndex = (tags, { unreleasedOnly, startingVersion, startingDate, tagP
       return index + 1
     }
     // Fall back to nearest version lower than startingVersion
-    return tags.findIndex(({ version }) => semver.lt(version, semverStartingVersion))
+    return tags.findIndex(({ version }) => version && semver.lt(version, semverStartingVersion))
   }
   if (startingDate) {
     return tags.filter(t => t.isoDate >= startingDate).length


### PR DESCRIPTION
If any tag object does not contains "version" property it throws error. This patch fixes this issue