### PR TITLE
Fixes #249: upgrade parse-github-url v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "handlebars": "^4.7.7",
     "import-cwd": "^3.0.0",
     "node-fetch": "^2.6.1",
-    "parse-github-url": "^1.0.2",
+    "parse-github-url": "^1.0.3",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,10 +2225,10 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-github-url@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.2.tgz#242d3b65cbcdda14bb50439e3242acf6971db395"
-  integrity sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==
+parse-github-url@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/parse-github-url/-/parse-github-url-1.0.3.tgz#2ab55642c8685b63fbe2a196f5abe4ae9bd68abc"
+  integrity sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==
 
 parse-json@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes cookpete#249

This error occurred when using parse-github-url v1.0.2 in a Node.js 20 environment, and the issue was resolved by upgrading parse-github-url to v1.0.3.


In Node.js 20, when using parse-github-url version 1.0.2, an error occurs when running based on the following SSH address.

```
npm install -g parse-github-url@1.0.2
parse-github-url git@github.com:cookpete/auto-changelog.git
```

```
(node:5774) [DEP0170] DeprecationWarning: The URL http://git@github.com:cookpete/auto-changelog.git is invalid. Future versions of Node.js will throw an error.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

In parse-github-url v1.0.3, this issue has been resolved.