### PR TITLE
[New] add monorepo autodetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
       --ignore-commit-pattern [regex] # pattern to ignore when parsing commits
       --tag-pattern [regex]           # override regex pattern for version tags
       --tag-prefix [prefix]           # prefix used in version tags, default: v
+      --autodetect-monorepo-disabled  # disable monorepo autodetection, default: true (will default to false in the next major)
       --starting-version [tag]        # specify earliest version to include in changelog
       --starting-date [yyyy-mm-dd]    # specify earliest date to include in changelog
       --ending-version [tag]          # specify latest version to include in changelog
@@ -169,6 +170,25 @@ Use `--tag-prefix [prefix]` if you prefix your version tags with a certain strin
 # When all versions are tagged like my-package/1.2.3
 auto-changelog --tag-prefix my-package/
 ```
+
+#### Monorepos
+
+In a monorepo, each package's version tags are typically prefixed with the package name, like `my-package@1.2.3`. When monorepo autodetection is enabled, `auto-changelog` detects a monorepo package — by a `repository.directory` field in `package.json`, or an ancestor `package.json` declaring npm `workspaces` — and, for a detected package:
+
+- derives the [tag prefix](#tag-prefixes) from the `name` in `package.json` (so you don't have to set `--tag-prefix` for every package), unless one is already configured, and
+- strips that prefix from the release titles in the changelog (so headings read `## [1.2.3]` rather than `## [my-package@1.2.3]`), while still using the full tags for the compare links.
+
+Autodetection is controlled by `--autodetect-monorepo-disabled`, which defaults to `true`. To opt in today, set it to `false`:
+
+```json
+{
+  "auto-changelog": {
+    "autodetectMonorepoDisabled": false
+  }
+}
+```
+
+This option **will default to `false` in the next major version**, enabling monorepo autodetection out of the box.
 
 #### Tag patterns
 

--- a/src/run.js
+++ b/src/run.js
@@ -1,3 +1,4 @@
+const { dirname, join } = require('path')
 const { Command } = require('commander')
 const importCwd = require('import-cwd')
 const { version } = require('../package.json')
@@ -14,6 +15,8 @@ const DEFAULT_OPTIONS = {
   commitLimit: 3,
   backfillLimit: 3,
   tagPrefix: '',
+  // TODO[major]: default to false so monorepo autodetection is on by default
+  autodetectMonorepoDisabled: true,
   sortCommits: 'relevance',
   appendGitLog: '',
   appendGitTag: '',
@@ -24,6 +27,26 @@ const DEFAULT_OPTIONS = {
 const PACKAGE_FILE = 'package.json'
 const PACKAGE_OPTIONS_KEY = 'auto-changelog'
 const PREPEND_TOKEN = '<!-- auto-changelog-above -->'
+
+// A package is part of a monorepo if it declares a `repository.directory`
+// (i.e. it lives in a subdirectory of a larger repo), or if an ancestor
+// package.json declares npm `workspaces`.
+const isMonorepoPackage = async pkg => {
+  if (pkg && pkg.repository && pkg.repository.directory) {
+    return true
+  }
+  let dir = process.cwd()
+  let parent = dirname(dir)
+  while (parent !== dir) {
+    const ancestor = await readJson(join(parent, PACKAGE_FILE))
+    if (ancestor && ancestor.workspaces) {
+      return true
+    }
+    dir = parent
+    parent = dirname(dir)
+  }
+  return false
+}
 
 const getOptions = async argv => {
   const commandOptions = new Command()
@@ -47,6 +70,7 @@ const getOptions = async argv => {
     .option('--ignore-commit-pattern <regex>', 'pattern to ignore when parsing commits')
     .option('--tag-pattern <regex>', 'override regex pattern for version tags')
     .option('--tag-prefix <prefix>', 'prefix used in version tags')
+    .option('--autodetect-monorepo-disabled', 'disable detecting a monorepo package and stripping its name-based tag prefix from release titles')
     .option('--starting-version <tag>', 'specify earliest version to include in changelog')
     .option('--starting-date <yyyy-mm-dd>', 'specify earliest date to include in changelog')
     .option('--ending-version <tag>', 'specify latest version to include in changelog')
@@ -73,6 +97,17 @@ const getOptions = async argv => {
     ...dotOptions,
     ...packageOptions,
     ...commandOptions
+  }
+  if (!options.autodetectMonorepoDisabled && await isMonorepoPackage(pkg)) {
+    if (!options.tagPrefix && pkg && pkg.name) {
+      // Monorepo version tags are conventionally prefixed with the package name
+      // (e.g. `my-package@1.2.3`), so derive the prefix from package.json rather
+      // than requiring it to be configured for every package.
+      options.tagPrefix = `${pkg.name}@`
+    }
+    // Strip the (derived or configured) prefix from release titles, while still
+    // using the full tags for compare links.
+    options.stripTagPrefix = true
   }
   const remote = await fetchRemote(options)
   const latestVersion = await getLatestVersion(options)

--- a/src/tags.js
+++ b/src/tags.js
@@ -13,11 +13,15 @@ const fetchTags = async (options, remote) => {
     .filter(isValidTag(options))
     .sort(sortTags(options))
 
-  const { latestVersion, unreleased, unreleasedOnly, getCompareLink } = options
+  const { latestVersion, unreleased, unreleasedOnly, getCompareLink, tagPrefix, stripTagPrefix } = options
   if (latestVersion || unreleased || unreleasedOnly) {
     const previous = tags[0]
     const v = !MATCH_V.test(latestVersion) && previous && MATCH_V.test(previous.version) ? 'v' : ''
-    const compareTo = latestVersion ? `${v}${latestVersion}` : 'HEAD'
+    // The title shows the bare version, but the compare link must target the real
+    // tag. In a monorepo that is prefixed with the package name, and the `v`
+    // convention (if any) still applies after that prefix (e.g. `my-package@v2.0.0`).
+    const prefix = stripTagPrefix && tagPrefix ? `${tagPrefix}${v}` : v
+    const compareTo = latestVersion ? `${prefix}${latestVersion}` : 'HEAD'
     tags.unshift({
       tag: null,
       title: latestVersion ? `${v}${latestVersion}` : 'Unreleased',
@@ -62,12 +66,12 @@ const getEndIndex = (tags, { unreleasedOnly, startingVersion, startingDate, tagP
   return tags.length
 }
 
-const parseTag = ({ tagPrefix }) => string => {
+const parseTag = ({ tagPrefix, stripTagPrefix }) => string => {
   const [tag, date] = string.split(DIVIDER)
   return {
     tag,
     date,
-    title: tag,
+    title: stripTagPrefix ? tag.replace(tagPrefix, '') : tag,
     version: inferSemver(tag.replace(tagPrefix, ''))
   }
 }

--- a/test/run.js
+++ b/test/run.js
@@ -53,6 +53,74 @@ test('getOptions: parses -i correctly when given -i', async t => {
   t.equal(options.issueUrl, 'https://test.issue.local/issues/{id}')
 })
 
+test('getOptions: autodetects a monorepo via repository.directory and derives the tag prefix', async t => {
+  mock('readJson', file => (file === 'package.json'
+    ? { name: 'my-package', repository: { directory: 'packages/my-package' }, 'auto-changelog': { autodetectMonorepoDisabled: false } }
+    : null))
+  try {
+    const options = await getOptions(['', ''])
+    t.equal(options.tagPrefix, 'my-package@')
+    t.equal(options.stripTagPrefix, true)
+  } finally {
+    unmock('readJson')
+  }
+})
+
+test('getOptions: autodetects a monorepo via an ancestor workspaces field', async t => {
+  mock('readJson', file => {
+    if (file === 'package.json') return { name: 'my-package', 'auto-changelog': { autodetectMonorepoDisabled: false } }
+    if (file.endsWith('package.json')) return { workspaces: ['packages/*'] }
+    return null
+  })
+  try {
+    const options = await getOptions(['', ''])
+    t.equal(options.tagPrefix, 'my-package@')
+    t.equal(options.stripTagPrefix, true)
+  } finally {
+    unmock('readJson')
+  }
+})
+
+test('getOptions: does not override an explicitly configured tag prefix', async t => {
+  mock('readJson', file => (file === 'package.json'
+    ? { name: 'my-package', repository: { directory: 'packages/my-package' }, 'auto-changelog': { autodetectMonorepoDisabled: false, tagPrefix: 'custom/' } }
+    : null))
+  try {
+    const options = await getOptions(['', ''])
+    t.equal(options.tagPrefix, 'custom/')
+    t.equal(options.stripTagPrefix, true)
+  } finally {
+    unmock('readJson')
+  }
+})
+
+test('getOptions: does not autodetect when the package is not in a monorepo', async t => {
+  mock('readJson', file => (file === 'package.json'
+    ? { name: 'my-package', 'auto-changelog': { autodetectMonorepoDisabled: false } }
+    : null))
+  try {
+    const options = await getOptions(['', ''])
+    t.equal(options.tagPrefix, '')
+    t.notOk(options.stripTagPrefix)
+  } finally {
+    unmock('readJson')
+  }
+})
+
+test('getOptions: does not autodetect a monorepo by default', async t => {
+  mock('readJson', file => (file === 'package.json'
+    ? { name: 'my-package', repository: { directory: 'packages/my-package' } }
+    : null))
+  try {
+    const options = await getOptions(['', ''])
+    t.equal(options.autodetectMonorepoDisabled, true)
+    t.equal(options.tagPrefix, '')
+    t.notOk(options.stripTagPrefix)
+  } finally {
+    unmock('readJson')
+  }
+})
+
 test('run: generates a changelog', async t => {
   setup()
   try {

--- a/test/tags.js
+++ b/test/tags.js
@@ -258,3 +258,52 @@ test('fetchTags: ignores invalid semver tags', async t => {
     unmock('cmd')
   }
 })
+
+test('fetchTags: strips the tag prefix from titles when stripTagPrefix is set', async t => {
+  mock('cmd', () => Promise.resolve([
+    'my-package@0.1.0---2000-02-01',
+    'my-package@1.0.0---2001-01-01'
+  ].join('\n')))
+  try {
+    const tags = await fetchTags({ ...options, tagPrefix: 'my-package@', stripTagPrefix: true })
+    t.deepEqual(tags.map(t => t.title), ['1.0.0', '0.1.0'], 'titles drop the prefix')
+    t.deepEqual(tags.map(t => t.version), ['1.0.0', '0.1.0'])
+    t.deepEqual(tags.map(t => t.tag), ['my-package@1.0.0', 'my-package@0.1.0'], 'tags keep the prefix')
+    t.equal(tags[0].href, 'https://github.com/user/repo/compare/my-package@0.1.0...my-package@1.0.0', 'compare link uses full tags')
+  } finally {
+    unmock('cmd')
+  }
+})
+
+test('fetchTags: keeps the tag prefix in titles by default', async t => {
+  mock('cmd', () => Promise.resolve('my-package@1.0.0---2001-01-01'))
+  try {
+    const tags = await fetchTags({ ...options, tagPrefix: 'my-package@' })
+    t.equal(tags[0].title, 'my-package@1.0.0')
+    t.equal(tags[0].version, '1.0.0')
+  } finally {
+    unmock('cmd')
+  }
+})
+
+test('fetchTags: targets the prefixed tag in the latest-version compare link when stripping', async t => {
+  mock('cmd', () => Promise.resolve('my-package@1.0.0---2001-01-01'))
+  try {
+    const tags = await fetchTags({ ...options, tagPrefix: 'my-package@', stripTagPrefix: true, latestVersion: '2.0.0' })
+    t.equal(tags[0].title, '2.0.0', 'latest title is the bare version')
+    t.equal(tags[0].href, 'https://github.com/user/repo/compare/my-package@1.0.0...my-package@2.0.0', 'links to the prefixed tag')
+  } finally {
+    unmock('cmd')
+  }
+})
+
+test('fetchTags: keeps the v convention after the package prefix in the latest-version compare link', async t => {
+  mock('cmd', () => Promise.resolve('my-package@v1.0.0---2001-01-01'))
+  try {
+    const tags = await fetchTags({ ...options, tagPrefix: 'my-package@', stripTagPrefix: true, latestVersion: '2.0.0' })
+    t.equal(tags[0].title, 'v2.0.0', 'latest title keeps the v convention')
+    t.equal(tags[0].href, 'https://github.com/user/repo/compare/my-package@v1.0.0...my-package@v2.0.0', 'links to the real prefixed v-tag')
+  } finally {
+    unmock('cmd')
+  }
+})


### PR DESCRIPTION
When enabled, detect that the current package is part of a monorepo - via a `repository.directory` field, or an ancestor `package.json` declaring npm `workspaces` - and, for a detected package:

- derive the tag prefix from the package `name` (e.g. `my-package@`) unless one is already configured, and
- strip that prefix from release titles, so headings read `## [1.2.3]` instead of `## [my-package@1.2.3]`, while still using the full tags for compare links.

Gated by the `autodetectMonorepoDisabled` option (`--autodetect-monorepo-disabled`), which defaults to `true` for backwards compatibility and is intended to default to `false` (enabling autodetection out of the box) in the next major version.